### PR TITLE
移除用户列表请求中分页参数的必填约束

### DIFF
--- a/api/admin/model.proto
+++ b/api/admin/model.proto
@@ -518,9 +518,9 @@ message RealtimeAlarmItem {
   // 告警级别
   SelectItem level = 5;
   // 告警级别ID
-  uint32 levelId = 6;
+  uint32 levelID = 6;
   // 告警策略ID
-  uint32 strategyId = 7;
+  uint32 strategyID = 7;
   // 告警策略
   StrategyItem strategy = 8;
   // 告警摘要
@@ -530,7 +530,7 @@ message RealtimeAlarmItem {
   // 触发告警表达式
   string expr = 11;
   // 数据源ID
-  uint32 datasourceId = 12;
+  uint32 datasourceID = 12;
   // 数据源
   DatasourceItem datasource = 13;
   // 指纹

--- a/api/admin/realtime/alarm.proto
+++ b/api/admin/realtime/alarm.proto
@@ -33,7 +33,10 @@ message GetAlarmRequest {
   // 告警ID
   uint32 id = 1;
 }
-message GetAlarmReply {}
+message GetAlarmReply {
+  // 告警详情
+  RealtimeAlarmItem detail = 1;
+}
 
 message ListAlarmRequest {
   // 分页

--- a/api/admin/realtime/dashboard.proto
+++ b/api/admin/realtime/dashboard.proto
@@ -83,11 +83,20 @@ message CreateDashboardReply {}
 
 message UpdateDashboardRequest {
 	// 仪表板ID
-	uint32 id = 1;
+	uint32 id = 1 [(buf.validate.field).cel = {
+		message: "请选择要操作的仪表",
+		expression: 'this > 0'
+	}];
 	// 仪表板名称
-	string title = 2;
+	string title = 2 [(buf.validate.field).cel = {
+		message: "仪表标题在1-20个字符",
+		expression: 'this.size() >= 1 && this.size() <= 20'
+	}];
 	// 仪表板说明
-	string remark = 3;
+	string remark = 3 [(buf.validate.field).cel = {
+		message: "仪表说明在200个字符以内",
+		expression: 'this.size() <= 200'
+	}];
 	// 仪表板颜色
 	string color = 4;
 	// 图表列表
@@ -145,7 +154,7 @@ message ListDashboardSelectRequest {
 	// 仪表板状态
 	Status status = 2;
 	// 分页
-	PaginationReq pagination = 3 [(buf.validate.field).required = true];
+	PaginationReq pagination = 3;
 }
 message ListDashboardSelectReply {
 	// 仪表板列表

--- a/api/admin/user/user.proto
+++ b/api/admin/user/user.proto
@@ -283,7 +283,7 @@ message ResetUserPasswordBySelfReply {}
 
 message GetUserSelectListRequest {
   // 分页参数
-  PaginationReq pagination = 1 [(buf.validate.field).required = true];
+  PaginationReq pagination = 1;
   // 关键字模糊查询
   string keyword = 2 [(buf.validate.field).cel = {
     message: "关键字模糊查询长度限制在0-20个字符",

--- a/api/merr/err.proto
+++ b/api/merr/err.proto
@@ -348,4 +348,11 @@ enum ErrorReason {
     (errors.message) = "告警数据不存在!",
     (errors.id) = "ALARM_DATA_NOT_FOUND_ERR"
   ];
+
+  // 仪表盘数据不存在
+  DASHBOARD_DATA_NOT_FOUND_ERR = 49 [
+    (errors.code) = 405,
+    (errors.message) = "仪表盘数据不存在!",
+    (errors.id) = "DASHBOARD_DATA_NOT_FOUND_ERR"
+  ];
 }

--- a/api/merr/err.proto
+++ b/api/merr/err.proto
@@ -328,15 +328,24 @@ enum ErrorReason {
     (errors.id) = "DICT_NOT_FOUND_ERR"
   ];
 
+  // 创建字典参数不能为空
   DICT_CREATE_PARAM_CANNOT_EMPTY = 46[
     (errors.code) = 405,
     (errors.message) = "创建字典参数不能为空!",
     (errors.id) = "DICT_CREATE_PARAM_CANNOT_EMPTY"
   ];
 
+  // 操作不允许
   OPERATION_NOT_ALLOWED_ERR = 47 [
     (errors.code) = 405,
     (errors.message) = "操作不允许!",
     (errors.id) = "OPERATION_NOT_ALLOWED_ERR"
+  ];
+
+  // 告警数据不存在
+  ALARM_DATA_NOT_FOUND_ERR = 48 [
+    (errors.code) = 405,
+    (errors.message) = "告警数据不存在!",
+    (errors.id) = "ALARM_DATA_NOT_FOUND_ERR"
   ];
 }

--- a/cmd/server/gen/gen_model.go
+++ b/cmd/server/gen/gen_model.go
@@ -45,6 +45,7 @@ func Run(datasource string, drive, outputPath string, isBiz bool) {
 
 	if isBiz {
 		g.ApplyBasic(bizmodel.Models()...)
+		g.ApplyBasic(bizmodel.AlarmModels()...)
 	} else {
 		g.ApplyBasic(model.Models()...)
 	}

--- a/cmd/server/palace/configs/config.yaml
+++ b/cmd/server/palace/configs/config.yaml
@@ -32,15 +32,15 @@ server:
 data:
   database:
     driver: "mysql"
-    debug: true
+    debug: false
     dsn: "root:12345678@tcp(localhost:3306)/moon?charset=utf8mb4&parseTime=True&loc=Local"
   bizDatabase:
     driver: "mysql"
-    debug: true
+    debug: false
     dsn: "root:12345678@tcp(localhost:3306)/"
   alarmDatabase:
     driver: "mysql"
-    debug: false
+    debug: true
     dsn: "root:12345678@tcp(localhost:3306)/"
   cache:
     redis:

--- a/cmd/server/palace/internal/biz/alarm.go
+++ b/cmd/server/palace/internal/biz/alarm.go
@@ -1,0 +1,31 @@
+package biz
+
+import (
+	"context"
+
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/repository"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+)
+
+// NewAlarmBiz 创建告警相关业务逻辑
+func NewAlarmBiz(alarmRepository repository.Alarm) *AlarmBiz {
+	return &AlarmBiz{
+		alarmRepository: alarmRepository,
+	}
+}
+
+// AlarmBiz 告警相关业务逻辑
+type AlarmBiz struct {
+	alarmRepository repository.Alarm
+}
+
+// GetRealTimeAlarm 获取实时告警明细
+func (b *AlarmBiz) GetRealTimeAlarm(ctx context.Context, params *bo.GetRealTimeAlarmParams) (*bizmodel.RealtimeAlarm, error) {
+	return b.alarmRepository.GetRealTimeAlarm(ctx, params)
+}
+
+// ListRealTimeAlarms 获取实时告警列表
+func (b *AlarmBiz) ListRealTimeAlarms(ctx context.Context, params *bo.GetRealTimeAlarmsParams) ([]*bizmodel.RealtimeAlarm, error) {
+	return b.alarmRepository.GetRealTimeAlarms(ctx, params)
+}

--- a/cmd/server/palace/internal/biz/bo/alarm.go
+++ b/cmd/server/palace/internal/biz/bo/alarm.go
@@ -1,0 +1,34 @@
+package bo
+
+import (
+	"github.com/aide-family/moon/pkg/util/types"
+	"github.com/aide-family/moon/pkg/vobj"
+)
+
+type (
+	// GetRealTimeAlarmParams 获取实时告警参数
+	GetRealTimeAlarmParams struct {
+		// 告警ID
+		RealtimeAlarmID uint32
+		// 告警指纹
+		Fingerprint string
+	}
+
+	// GetRealTimeAlarmsParams 获取实时告警列表参数
+	GetRealTimeAlarmsParams struct {
+		// 分页参数
+		Pagination types.Pagination
+		// 告警时间范围
+		EventAtStart int64
+		EventAtEnd   int64
+		// 告警恢复时间
+		ResolvedAtStart int64
+		ResolvedAtEnd   int64
+		// 告警级别
+		AlarmLevels []uint32
+		// 告警状态
+		AlarmStatuses []vobj.AlertStatus
+		// 关键字
+		Keyword string
+	}
+)

--- a/cmd/server/palace/internal/biz/bo/dashboard.go
+++ b/cmd/server/palace/internal/biz/bo/dashboard.go
@@ -25,12 +25,13 @@ type (
 		Remark         string
 		Color          string
 		Charts         []*ChartItem
-		StrategyGroups uint32
+		StrategyGroups []uint32
 	}
 
 	// DeleteDashboardParams 删除仪表盘请求参数
 	DeleteDashboardParams struct {
-		ID uint32
+		ID     uint32
+		Status vobj.Status
 	}
 
 	// UpdateDashboardParams 更新仪表盘请求参数
@@ -38,9 +39,10 @@ type (
 		ID             uint32
 		Name           string
 		Remark         string
+		Status         vobj.Status
 		Color          string
 		Charts         []*ChartItem
-		StrategyGroups uint32
+		StrategyGroups []uint32
 	}
 
 	// ListDashboardParams 仪表盘列表请求参数

--- a/cmd/server/palace/internal/biz/bo/dashboard.go
+++ b/cmd/server/palace/internal/biz/bo/dashboard.go
@@ -1,0 +1,52 @@
+package bo
+
+import (
+	"github.com/aide-family/moon/pkg/util/types"
+	"github.com/aide-family/moon/pkg/vobj"
+)
+
+type (
+	// ChartItem 仪表盘图表明细
+	ChartItem struct {
+		ID          uint32
+		Name        string
+		Remark      string
+		URL         string
+		Status      vobj.Status
+		Height      string
+		Width       string
+		ChartType   vobj.DashboardChartType
+		DashboardID uint32
+	}
+
+	// AddDashboardParams 添加仪表盘请求参数
+	AddDashboardParams struct {
+		Name           string
+		Remark         string
+		Color          string
+		Charts         []*ChartItem
+		StrategyGroups uint32
+	}
+
+	// DeleteDashboardParams 删除仪表盘请求参数
+	DeleteDashboardParams struct {
+		ID uint32
+	}
+
+	// UpdateDashboardParams 更新仪表盘请求参数
+	UpdateDashboardParams struct {
+		ID             uint32
+		Name           string
+		Remark         string
+		Color          string
+		Charts         []*ChartItem
+		StrategyGroups uint32
+	}
+
+	// ListDashboardParams 仪表盘列表请求参数
+	ListDashboardParams struct {
+		Page    types.Pagination
+		Keyword string
+		Status  vobj.Status
+	}
+)

--- a/cmd/server/palace/internal/biz/dashboard.go
+++ b/cmd/server/palace/internal/biz/dashboard.go
@@ -1,0 +1,46 @@
+package biz
+
+import (
+	"context"
+
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/repository"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+)
+
+// NewDashboardBiz 创建仪表盘业务
+func NewDashboardBiz(dashboardRepository repository.Dashboard) *DashboardBiz {
+	return &DashboardBiz{
+		dashboardRepository: dashboardRepository,
+	}
+}
+
+// DashboardBiz  仪表盘业务
+type DashboardBiz struct {
+	dashboardRepository repository.Dashboard
+}
+
+// CreateDashboard 创建仪表盘
+func (b *DashboardBiz) CreateDashboard(ctx context.Context, req *bo.AddDashboardParams) error {
+	return b.dashboardRepository.AddDashboard(ctx, req)
+}
+
+// UpdateDashboard 更新仪表盘
+func (b *DashboardBiz) UpdateDashboard(ctx context.Context, req *bo.UpdateDashboardParams) error {
+	return b.dashboardRepository.UpdateDashboard(ctx, req)
+}
+
+// DeleteDashboard 删除仪表盘
+func (b *DashboardBiz) DeleteDashboard(ctx context.Context, req *bo.DeleteDashboardParams) error {
+	return b.dashboardRepository.DeleteDashboard(ctx, req)
+}
+
+// GetDashboard 获取仪表盘
+func (b *DashboardBiz) GetDashboard(ctx context.Context, id uint32) (*bizmodel.Dashboard, error) {
+	return b.dashboardRepository.GetDashboard(ctx, id)
+}
+
+// ListDashboard 获取仪表盘列表
+func (b *DashboardBiz) ListDashboard(ctx context.Context, params *bo.ListDashboardParams) ([]*bizmodel.Dashboard, error) {
+	return b.dashboardRepository.ListDashboard(ctx, params)
+}

--- a/cmd/server/palace/internal/biz/register.go
+++ b/cmd/server/palace/internal/biz/register.go
@@ -19,4 +19,5 @@ var ProviderSetBiz = wire.NewSet(
 	NewDictBiz,
 	NewTemplateBiz,
 	NewAlarmBiz,
+	NewDashboardBiz,
 )

--- a/cmd/server/palace/internal/biz/register.go
+++ b/cmd/server/palace/internal/biz/register.go
@@ -18,4 +18,5 @@ var ProviderSetBiz = wire.NewSet(
 	NewMetricBiz,
 	NewDictBiz,
 	NewTemplateBiz,
+	NewAlarmBiz,
 )

--- a/cmd/server/palace/internal/biz/repository/alarm.go
+++ b/cmd/server/palace/internal/biz/repository/alarm.go
@@ -1,0 +1,17 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+)
+
+// Alarm 告警相关接口定义
+type Alarm interface {
+	// GetRealTimeAlarm 获取实时告警
+	GetRealTimeAlarm(ctx context.Context, params *bo.GetRealTimeAlarmParams) (*bizmodel.RealtimeAlarm, error)
+
+	// GetRealTimeAlarms 获取实时告警列表
+	GetRealTimeAlarms(ctx context.Context, params *bo.GetRealTimeAlarmsParams) ([]*bizmodel.RealtimeAlarm, error)
+}

--- a/cmd/server/palace/internal/biz/repository/dashboard.go
+++ b/cmd/server/palace/internal/biz/repository/dashboard.go
@@ -1,0 +1,26 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+)
+
+// Dashboard 仪表盘相关操作接口
+type Dashboard interface {
+	// AddDashboard 添加仪表盘
+	AddDashboard(ctx context.Context, req *bo.AddDashboardParams) error
+
+	// DeleteDashboard 删除仪表盘
+	DeleteDashboard(ctx context.Context, req *bo.DeleteDashboardParams) error
+
+	// UpdateDashboard 更新仪表盘
+	UpdateDashboard(ctx context.Context, req *bo.UpdateDashboardParams) error
+
+	// GetDashboard 获取仪表盘详情
+	GetDashboard(ctx context.Context, id uint32) (*bizmodel.Dashboard, error)
+
+	// ListDashboard 获取仪表盘列表
+	ListDashboard(ctx context.Context, params *bo.ListDashboardParams) ([]*bizmodel.Dashboard, error)
+}

--- a/cmd/server/palace/internal/data/repoimpl/dashboard.go
+++ b/cmd/server/palace/internal/data/repoimpl/dashboard.go
@@ -3,10 +3,19 @@ package repoimpl
 import (
 	"context"
 
+	"github.com/aide-family/moon/api/merr"
 	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
 	"github.com/aide-family/moon/cmd/server/palace/internal/biz/repository"
 	"github.com/aide-family/moon/cmd/server/palace/internal/data"
+	"github.com/aide-family/moon/cmd/server/palace/internal/service/build"
+	"github.com/aide-family/moon/pkg/palace/model"
 	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel/bizquery"
+	"github.com/aide-family/moon/pkg/util/types"
+	"gorm.io/gen"
+
+	"github.com/go-kratos/kratos/v2/errors"
+	"gorm.io/gorm"
 )
 
 // NewDashboardRepository 创建仪表盘操作实现
@@ -19,26 +28,109 @@ type dashboardRepositoryImpl struct {
 }
 
 func (d *dashboardRepositoryImpl) AddDashboard(ctx context.Context, req *bo.AddDashboardParams) error {
-	//TODO implement me
-	panic("implement me")
+	dashboardModuleBuilder := build.NewBuilder().DashboardModule().WithBoAddDashboardParams(req)
+	dashboardModel := dashboardModuleBuilder.ToDo()
+	bizQuery, err := getBizQuery(ctx, d.data)
+	if err != nil {
+		return err
+	}
+	return bizQuery.Transaction(func(tx *bizquery.Query) error {
+		if err = bizQuery.Dashboard.WithContext(ctx).Create(dashboardModel); err != nil {
+			return err
+		}
+		strategyGroups := dashboardModuleBuilder.WithDashboardID(dashboardModel.ID).ToDoStrategyGroups()
+		if err = bizQuery.Dashboard.StrategyGroups.Model(dashboardModel).Append(strategyGroups...); err != nil {
+			return err
+		}
+		charts := dashboardModuleBuilder.WithDashboardID(dashboardModel.ID).ToDoCharts()
+		if err = bizQuery.Dashboard.Charts.Model(dashboardModel).Append(charts...); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func (d *dashboardRepositoryImpl) DeleteDashboard(ctx context.Context, req *bo.DeleteDashboardParams) error {
-	//TODO implement me
-	panic("implement me")
+	bizQuery, err := getBizQuery(ctx, d.data)
+	if err != nil {
+		return err
+	}
+	dashboardModel := &bizmodel.Dashboard{
+		AllFieldModel: model.AllFieldModel{ID: req.ID},
+	}
+	return bizQuery.Transaction(func(tx *bizquery.Query) error {
+		if err = bizQuery.Dashboard.Charts.Model(dashboardModel).Clear(); err != nil {
+			return err
+		}
+		if err = bizQuery.Dashboard.StrategyGroups.Model(dashboardModel).Clear(); err != nil {
+			return err
+		}
+		_, err = bizQuery.Dashboard.WithContext(ctx).Where(bizQuery.Dashboard.ID.Eq(req.ID), bizQuery.Dashboard.Status.Eq(req.Status.GetValue())).Delete()
+		return err
+	})
 }
 
 func (d *dashboardRepositoryImpl) UpdateDashboard(ctx context.Context, req *bo.UpdateDashboardParams) error {
-	//TODO implement me
-	panic("implement me")
+	dashboardModuleBuilder := build.NewBuilder().DashboardModule().WithBoUpdateDashboardParams(req)
+	dashboardModel := dashboardModuleBuilder.ToDo()
+	strategyGroups := dashboardModuleBuilder.ToDoStrategyGroups()
+	charts := dashboardModuleBuilder.ToDoCharts()
+	bizQuery, err := getBizQuery(ctx, d.data)
+	if err != nil {
+		return err
+	}
+
+	return bizQuery.Transaction(func(tx *bizquery.Query) error {
+		// 替换仪表盘图表
+		if err = tx.Dashboard.Charts.Model(dashboardModel).Replace(charts...); err != nil {
+			return err
+		}
+		// 替换策略组
+		if err = tx.Dashboard.StrategyGroups.Model(dashboardModel).Replace(strategyGroups...); err != nil {
+			return err
+		}
+		_, err = tx.Dashboard.WithContext(ctx).
+			Where(bizQuery.Dashboard.ID.Eq(req.ID)).
+			UpdateSimple(
+				tx.Dashboard.Color.Value(dashboardModel.Color),
+				tx.Dashboard.Name.Value(dashboardModel.Name),
+				tx.Dashboard.Remark.Value(dashboardModel.Remark),
+				tx.Dashboard.Status.Value(dashboardModel.Status.GetValue()),
+			)
+		return err
+	})
 }
 
 func (d *dashboardRepositoryImpl) GetDashboard(ctx context.Context, id uint32) (*bizmodel.Dashboard, error) {
-	//TODO implement me
-	panic("implement me")
+	bizQuery, err := getBizQuery(ctx, d.data)
+	if err != nil {
+		return nil, err
+	}
+	detail, err := bizQuery.Dashboard.WithContext(ctx).Where(bizQuery.Dashboard.ID.Eq(id)).First()
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, merr.ErrorI18nDashboardDataNotFoundErr(ctx).WithCause(err)
+		}
+		return nil, merr.ErrorI18nSystemErr(ctx).WithCause(err)
+	}
+	return detail, nil
 }
 
 func (d *dashboardRepositoryImpl) ListDashboard(ctx context.Context, params *bo.ListDashboardParams) ([]*bizmodel.Dashboard, error) {
-	//TODO implement me
-	panic("implement me")
+	bizQuery, err := getBizQuery(ctx, d.data)
+	if err != nil {
+		return nil, err
+	}
+	wheres := make([]gen.Condition, 0, 2)
+	if !types.TextIsNull(params.Keyword) {
+		wheres = append(wheres, bizQuery.Dashboard.Name.Like(params.Keyword))
+	}
+	if !params.Status.IsUnknown() {
+		wheres = append(wheres, bizQuery.Dashboard.Status.Eq(params.Status.GetValue()))
+	}
+	dashboardQuery := bizQuery.Dashboard.WithContext(ctx).Where(wheres...)
+	if err = types.WithPageQuery[bizquery.IDashboardDo](dashboardQuery, params.Page); err != nil {
+		return nil, err
+	}
+	return dashboardQuery.Find()
 }

--- a/cmd/server/palace/internal/data/repoimpl/dashboard.go
+++ b/cmd/server/palace/internal/data/repoimpl/dashboard.go
@@ -12,9 +12,9 @@ import (
 	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
 	"github.com/aide-family/moon/pkg/palace/model/bizmodel/bizquery"
 	"github.com/aide-family/moon/pkg/util/types"
-	"gorm.io/gen"
 
 	"github.com/go-kratos/kratos/v2/errors"
+	"gorm.io/gen"
 	"gorm.io/gorm"
 )
 

--- a/cmd/server/palace/internal/data/repoimpl/dashboard.go
+++ b/cmd/server/palace/internal/data/repoimpl/dashboard.go
@@ -1,0 +1,44 @@
+package repoimpl
+
+import (
+	"context"
+
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/repository"
+	"github.com/aide-family/moon/cmd/server/palace/internal/data"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+)
+
+// NewDashboardRepository 创建仪表盘操作实现
+func NewDashboardRepository(data *data.Data) repository.Dashboard {
+	return &dashboardRepositoryImpl{data: data}
+}
+
+type dashboardRepositoryImpl struct {
+	data *data.Data
+}
+
+func (d *dashboardRepositoryImpl) AddDashboard(ctx context.Context, req *bo.AddDashboardParams) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (d *dashboardRepositoryImpl) DeleteDashboard(ctx context.Context, req *bo.DeleteDashboardParams) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (d *dashboardRepositoryImpl) UpdateDashboard(ctx context.Context, req *bo.UpdateDashboardParams) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (d *dashboardRepositoryImpl) GetDashboard(ctx context.Context, id uint32) (*bizmodel.Dashboard, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (d *dashboardRepositoryImpl) ListDashboard(ctx context.Context, params *bo.ListDashboardParams) ([]*bizmodel.Dashboard, error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/cmd/server/palace/internal/data/repoimpl/realtime_alarm.go
+++ b/cmd/server/palace/internal/data/repoimpl/realtime_alarm.go
@@ -12,12 +12,14 @@ import (
 	"github.com/aide-family/moon/pkg/palace/model/bizmodel/bizquery"
 	"github.com/aide-family/moon/pkg/util/types"
 	"github.com/aide-family/moon/pkg/vobj"
+
 	"github.com/go-kratos/kratos/v2/errors"
 	"gorm.io/gen"
 	"gorm.io/gen/field"
 	"gorm.io/gorm"
 )
 
+// NewRealtimeAlarmRepository 实例化告警业务数据库
 func NewRealtimeAlarmRepository(data *data.Data) repository.Alarm {
 	return &realtimeAlarmRepositoryImpl{data: data}
 }

--- a/cmd/server/palace/internal/data/repoimpl/realtime_alarm.go
+++ b/cmd/server/palace/internal/data/repoimpl/realtime_alarm.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/go-kratos/kratos/v2/errors"
 	"gorm.io/gen"
-	"gorm.io/gen/field"
 	"gorm.io/gorm"
 )
 
@@ -53,9 +52,7 @@ func (r *realtimeAlarmRepositoryImpl) GetRealTimeAlarm(ctx context.Context, para
 	if params.RealtimeAlarmID != 0 {
 		wheres = append(wheres, alarmQuery.RealtimeAlarm.ID.Eq(params.RealtimeAlarmID))
 	}
-	detail, err := alarmQuery.WithContext(ctx).RealtimeAlarm.Where(wheres...).
-		Preload(field.Associations).
-		First()
+	detail, err := alarmQuery.WithContext(ctx).RealtimeAlarm.Where(wheres...).First()
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, merr.ErrorI18nAlarmDataNotFoundErr(ctx).WithCause(err)

--- a/cmd/server/palace/internal/data/repoimpl/realtime_alarm.go
+++ b/cmd/server/palace/internal/data/repoimpl/realtime_alarm.go
@@ -1,0 +1,96 @@
+package repoimpl
+
+import (
+	"context"
+
+	"github.com/aide-family/moon/api/merr"
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/repository"
+	"github.com/aide-family/moon/cmd/server/palace/internal/data"
+	"github.com/aide-family/moon/pkg/helper/middleware"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel/bizquery"
+	"github.com/aide-family/moon/pkg/util/types"
+	"github.com/aide-family/moon/pkg/vobj"
+	"github.com/go-kratos/kratos/v2/errors"
+	"gorm.io/gen"
+	"gorm.io/gen/field"
+	"gorm.io/gorm"
+)
+
+func NewRealtimeAlarmRepository(data *data.Data) repository.Alarm {
+	return &realtimeAlarmRepositoryImpl{data: data}
+}
+
+type realtimeAlarmRepositoryImpl struct {
+	data *data.Data
+}
+
+// getBizQuery 获取告警业务数据库
+func getBizAlarmQuery(ctx context.Context, data *data.Data) (*bizquery.Query, error) {
+	claims, ok := middleware.ParseJwtClaims(ctx)
+	if !ok {
+		return nil, merr.ErrorI18nUnLoginErr(ctx)
+	}
+	bizDB, err := data.GetAlarmGormDB(claims.GetTeam())
+	if !types.IsNil(err) {
+		return nil, err
+	}
+	return bizquery.Use(bizDB), nil
+}
+
+func (r *realtimeAlarmRepositoryImpl) GetRealTimeAlarm(ctx context.Context, params *bo.GetRealTimeAlarmParams) (*bizmodel.RealtimeAlarm, error) {
+	alarmQuery, err := getBizAlarmQuery(ctx, r.data)
+	if err != nil {
+		return nil, err
+	}
+	var wheres []gen.Condition
+	if !types.TextIsNull(params.Fingerprint) {
+		wheres = append(wheres, alarmQuery.RealtimeAlarm.Fingerprint.Eq(params.Fingerprint))
+	}
+	if params.RealtimeAlarmID != 0 {
+		wheres = append(wheres, alarmQuery.RealtimeAlarm.ID.Eq(params.RealtimeAlarmID))
+	}
+	detail, err := alarmQuery.WithContext(ctx).RealtimeAlarm.Where(wheres...).
+		Preload(field.Associations).
+		First()
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, merr.ErrorI18nAlarmDataNotFoundErr(ctx).WithCause(err)
+		}
+		return nil, merr.ErrorI18nSystemErr(ctx).WithCause(err)
+	}
+	return detail, nil
+}
+
+func (r *realtimeAlarmRepositoryImpl) GetRealTimeAlarms(ctx context.Context, params *bo.GetRealTimeAlarmsParams) ([]*bizmodel.RealtimeAlarm, error) {
+	alarmQuery, err := getBizAlarmQuery(ctx, r.data)
+	if err != nil {
+		return nil, err
+	}
+	var wheres []gen.Condition
+	if params.EventAtStart < params.EventAtEnd && params.EventAtStart > 0 {
+		wheres = append(wheres, alarmQuery.RealtimeAlarm.StartsAt.Between(params.EventAtStart, params.EventAtEnd))
+	}
+	if params.ResolvedAtStart < params.ResolvedAtEnd && params.ResolvedAtStart > 0 {
+		wheres = append(wheres, alarmQuery.RealtimeAlarm.Status.Eq(vobj.AlertStatusResolved.GetValue()))
+		wheres = append(wheres, alarmQuery.RealtimeAlarm.EndsAt.Between(params.ResolvedAtStart, params.ResolvedAtEnd))
+	}
+	if len(params.AlarmLevels) > 0 {
+		wheres = append(wheres, alarmQuery.RealtimeAlarm.LevelID.In(params.AlarmLevels...))
+	}
+	if len(params.AlarmStatuses) > 0 {
+		statuses := types.SliceTo(params.AlarmStatuses, func(status vobj.AlertStatus) int {
+			return status.GetValue()
+		})
+		wheres = append(wheres, alarmQuery.RealtimeAlarm.Status.In(statuses...))
+	}
+	if !types.TextIsNull(params.Keyword) {
+		wheres = append(wheres, alarmQuery.RealtimeAlarm.RawInfo.Like(params.Keyword))
+	}
+	realtimeAlarmQuery := alarmQuery.WithContext(ctx).RealtimeAlarm.Where(wheres...)
+	if err := types.WithPageQuery[bizquery.IRealtimeAlarmDo](realtimeAlarmQuery, params.Pagination); err != nil {
+		return nil, err
+	}
+	return realtimeAlarmQuery.Find()
+}

--- a/cmd/server/palace/internal/data/repoimpl/register.go
+++ b/cmd/server/palace/internal/data/repoimpl/register.go
@@ -23,4 +23,5 @@ var ProviderSetRepoImpl = wire.NewSet(
 	NewStrategyRepository,
 	NewStrategyGroupRepository,
 	NewRealtimeAlarmRepository,
+	NewDashboardRepository,
 )

--- a/cmd/server/palace/internal/data/repoimpl/register.go
+++ b/cmd/server/palace/internal/data/repoimpl/register.go
@@ -22,4 +22,5 @@ var ProviderSetRepoImpl = wire.NewSet(
 	NewTemplateRepository,
 	NewStrategyRepository,
 	NewStrategyGroupRepository,
+	NewRealtimeAlarmRepository,
 )

--- a/cmd/server/palace/internal/service/build/alarm.go
+++ b/cmd/server/palace/internal/service/build/alarm.go
@@ -145,20 +145,20 @@ func (r *doRealtimeAlarmBuilder) ToAPI() *adminapi.RealtimeAlarmItem {
 	}
 	detail := r.alarm
 	return &adminapi.RealtimeAlarmItem{
-		Id:           detail.ID,
-		StartsAt:     types.NewTimeByUnix(detail.StartsAt).String(),
-		EndsAt:       types.NewTimeByUnix(detail.EndsAt).String(),
-		Status:       api.AlertStatus(detail.Status),
-		Level:        NewBuilder().WithDict(detail.Level).ToAPISelect(),
-		LevelID:      detail.LevelID,
-		StrategyID:   detail.StrategyID,
-		Strategy:     NewBuilder().WithContext(r.ctx).WithAPIStrategy(detail.Strategy).ToAPI(),
+		Id:       detail.ID,
+		StartsAt: types.NewTimeByUnix(detail.StartsAt).String(),
+		EndsAt:   types.NewTimeByUnix(detail.EndsAt).String(),
+		Status:   api.AlertStatus(detail.Status),
+		//Level:        NewBuilder().WithDict(detail.Level).ToAPISelect(),
+		LevelID:    detail.LevelID,
+		StrategyID: detail.StrategyID,
+		//Strategy:     NewBuilder().WithContext(r.ctx).WithAPIStrategy(detail.Strategy).ToAPI(),
 		Summary:      detail.Summary,
 		Description:  detail.Description,
 		Expr:         detail.Expr,
 		DatasourceID: detail.DatasourceID,
-		Datasource:   NewBuilder().WithDoDatasource(detail.Datasource).ToAPI(),
-		Fingerprint:  detail.Fingerprint,
+		//Datasource:   NewBuilder().WithDoDatasource(detail.Datasource).ToAPI(),
+		Fingerprint: detail.Fingerprint,
 	}
 }
 

--- a/cmd/server/palace/internal/service/build/alarm.go
+++ b/cmd/server/palace/internal/service/build/alarm.go
@@ -10,6 +10,7 @@ import (
 )
 
 type (
+	// RealtimeAlarmBuilder realtime alarm builder
 	RealtimeAlarmBuilder interface {
 		ToAPI() *adminapi.RealtimeAlarmItem
 	}
@@ -43,6 +44,7 @@ func (r *realtimeAlarmBuilder) ToAPI() *adminapi.RealtimeAlarmItem {
 	}
 }
 
+// NewRealtimeAlarmBuilder new realtime alarm builder
 func NewRealtimeAlarmBuilder(ctx context.Context, alarm *bizmodel.RealtimeAlarm) RealtimeAlarmBuilder {
 	return &realtimeAlarmBuilder{alarm: alarm, ctx: ctx}
 }

--- a/cmd/server/palace/internal/service/build/alarm.go
+++ b/cmd/server/palace/internal/service/build/alarm.go
@@ -5,23 +5,141 @@ import (
 
 	"github.com/aide-family/moon/api"
 	adminapi "github.com/aide-family/moon/api/admin"
+	realtimeapi "github.com/aide-family/moon/api/admin/realtime"
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
 	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
 	"github.com/aide-family/moon/pkg/util/types"
+	"github.com/aide-family/moon/pkg/vobj"
 )
 
 type (
-	// RealtimeAlarmBuilder realtime alarm builder
-	RealtimeAlarmBuilder interface {
+	// RealtimeAlarmModuleBuilder 实时告警模块构造器
+	RealtimeAlarmModuleBuilder interface {
+		WithDoRealtimeAlarm(*bizmodel.RealtimeAlarm) DoRealtimeAlarmBuilder
+		WithDostRealtimeAlarm([]*bizmodel.RealtimeAlarm) DostRealtimeAlarmBuilder
+		WithContext(context.Context) RealtimeAlarmModuleBuilder
+		WithAPIGetAlarmRequest(*realtimeapi.GetAlarmRequest) APIGetRealTimeAlarmParamsBuilder
+		WithAPIListAlarmRequest(*realtimeapi.ListAlarmRequest) APIListAlarmParamsBuilder
+	}
+
+	// DoRealtimeAlarmBuilder do realtime alarm builder
+	DoRealtimeAlarmBuilder interface {
 		ToAPI() *adminapi.RealtimeAlarmItem
 	}
 
-	realtimeAlarmBuilder struct {
+	// DostRealtimeAlarmBuilder do realtime alarm builder
+	DostRealtimeAlarmBuilder interface {
+		ToAPIs() []*adminapi.RealtimeAlarmItem
+	}
+
+	// APIGetRealTimeAlarmParamsBuilder get realtime alarm params builder
+	APIGetRealTimeAlarmParamsBuilder interface {
+		ToBo() *bo.GetRealTimeAlarmParams
+		WithFingerprint(fingerprint string) APIGetRealTimeAlarmParamsBuilder
+	}
+
+	// APIListAlarmParamsBuilder get realtime alarm params builder
+	APIListAlarmParamsBuilder interface {
+		ToBo() *bo.GetRealTimeAlarmsParams
+	}
+
+	doRealtimeAlarmBuilder struct {
 		alarm *bizmodel.RealtimeAlarm
 		ctx   context.Context
 	}
+
+	dostRealtimeAlarmBuilder struct {
+		alarms []*bizmodel.RealtimeAlarm
+		ctx    context.Context
+	}
+
+	realtimeAlarmModuleBuilder struct {
+		ctx context.Context
+	}
+
+	apiGetRealTimeAlarmParamsBuilder struct {
+		ctx         context.Context
+		req         *realtimeapi.GetAlarmRequest
+		fingerprint string
+	}
+
+	apiGetRealTimeAlarmsParamsBuilder struct {
+		ctx    context.Context
+		params *realtimeapi.ListAlarmRequest
+	}
 )
 
-func (r *realtimeAlarmBuilder) ToAPI() *adminapi.RealtimeAlarmItem {
+func (a *apiGetRealTimeAlarmsParamsBuilder) ToBo() *bo.GetRealTimeAlarmsParams {
+	if types.IsNil(a) || types.IsNil(a.params) {
+		return nil
+	}
+	params := a.params
+	return &bo.GetRealTimeAlarmsParams{
+		Pagination:      types.NewPagination(params.GetPagination()),
+		EventAtStart:    params.GetEventAtStart(),
+		EventAtEnd:      params.GetEventAtEnd(),
+		ResolvedAtStart: params.GetRecoverAtStart(),
+		ResolvedAtEnd:   params.GetRecoverAtEnd(),
+		AlarmLevels:     params.GetAlarmLevels(),
+		AlarmStatuses:   types.SliceTo(params.GetAlarmStatuses(), func(item api.AlertStatus) vobj.AlertStatus { return vobj.AlertStatus(item) }),
+		Keyword:         params.GetKeyword(),
+	}
+}
+
+func (a *apiGetRealTimeAlarmParamsBuilder) WithFingerprint(fingerprint string) APIGetRealTimeAlarmParamsBuilder {
+	if types.IsNil(a) || types.IsNil(a.req) {
+		return newAPIGetRealTimeAlarmParamsBuilder(context.TODO(), &realtimeapi.GetAlarmRequest{}).WithFingerprint(fingerprint)
+	}
+	a.fingerprint = fingerprint
+	return a
+}
+
+func (a *apiGetRealTimeAlarmParamsBuilder) ToBo() *bo.GetRealTimeAlarmParams {
+	if types.IsNil(a) || types.IsNil(a.req) {
+		return nil
+	}
+	params := a.req
+	return &bo.GetRealTimeAlarmParams{
+		RealtimeAlarmID: params.GetId(),
+		Fingerprint:     "",
+	}
+}
+
+func (r *realtimeAlarmModuleBuilder) WithAPIListAlarmRequest(request *realtimeapi.ListAlarmRequest) APIListAlarmParamsBuilder {
+	return newAPIListAlarmParamsBuilder(r.ctx, request)
+}
+
+func (r *realtimeAlarmModuleBuilder) WithAPIGetAlarmRequest(request *realtimeapi.GetAlarmRequest) APIGetRealTimeAlarmParamsBuilder {
+	return newAPIGetRealTimeAlarmParamsBuilder(r.ctx, request)
+}
+
+func (r *realtimeAlarmModuleBuilder) WithContext(ctx context.Context) RealtimeAlarmModuleBuilder {
+	if types.IsNil(r) {
+		return newRealtimeAlarmModuleBuilder(ctx)
+	}
+	r.ctx = ctx
+	return r
+}
+
+func (r *realtimeAlarmModuleBuilder) WithDoRealtimeAlarm(alarm *bizmodel.RealtimeAlarm) DoRealtimeAlarmBuilder {
+	return newDoRealtimeAlarmBuilder(r.ctx, alarm)
+}
+
+func (r *realtimeAlarmModuleBuilder) WithDostRealtimeAlarm(alarms []*bizmodel.RealtimeAlarm) DostRealtimeAlarmBuilder {
+	return newDostRealtimeAlarmBuilder(r.ctx, alarms)
+}
+
+func (d *dostRealtimeAlarmBuilder) ToAPIs() []*adminapi.RealtimeAlarmItem {
+	if types.IsNil(d) || types.IsNil(d.alarms) {
+		return nil
+	}
+	alarms := d.alarms
+	return types.SliceTo(alarms, func(alarm *bizmodel.RealtimeAlarm) *adminapi.RealtimeAlarmItem {
+		return newDoRealtimeAlarmBuilder(d.ctx, alarm).ToAPI()
+	})
+}
+
+func (r *doRealtimeAlarmBuilder) ToAPI() *adminapi.RealtimeAlarmItem {
 	if types.IsNil(r) || types.IsNil(r.alarm) {
 		return nil
 	}
@@ -44,7 +162,22 @@ func (r *realtimeAlarmBuilder) ToAPI() *adminapi.RealtimeAlarmItem {
 	}
 }
 
-// NewRealtimeAlarmBuilder new realtime alarm builder
-func NewRealtimeAlarmBuilder(ctx context.Context, alarm *bizmodel.RealtimeAlarm) RealtimeAlarmBuilder {
-	return &realtimeAlarmBuilder{alarm: alarm, ctx: ctx}
+func newRealtimeAlarmModuleBuilder(ctx context.Context) RealtimeAlarmModuleBuilder {
+	return &realtimeAlarmModuleBuilder{ctx: ctx}
+}
+
+func newDoRealtimeAlarmBuilder(ctx context.Context, alarm *bizmodel.RealtimeAlarm) DoRealtimeAlarmBuilder {
+	return &doRealtimeAlarmBuilder{alarm: alarm, ctx: ctx}
+}
+
+func newDostRealtimeAlarmBuilder(ctx context.Context, alarms []*bizmodel.RealtimeAlarm) DostRealtimeAlarmBuilder {
+	return &dostRealtimeAlarmBuilder{alarms: alarms, ctx: ctx}
+}
+
+func newAPIGetRealTimeAlarmParamsBuilder(ctx context.Context, req *realtimeapi.GetAlarmRequest) APIGetRealTimeAlarmParamsBuilder {
+	return &apiGetRealTimeAlarmParamsBuilder{ctx: ctx, req: req}
+}
+
+func newAPIListAlarmParamsBuilder(ctx context.Context, params *realtimeapi.ListAlarmRequest) APIListAlarmParamsBuilder {
+	return &apiGetRealTimeAlarmsParamsBuilder{ctx: ctx, params: params}
 }

--- a/cmd/server/palace/internal/service/build/alarm.go
+++ b/cmd/server/palace/internal/service/build/alarm.go
@@ -1,0 +1,48 @@
+package build
+
+import (
+	"context"
+
+	"github.com/aide-family/moon/api"
+	adminapi "github.com/aide-family/moon/api/admin"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+	"github.com/aide-family/moon/pkg/util/types"
+)
+
+type (
+	RealtimeAlarmBuilder interface {
+		ToAPI() *adminapi.RealtimeAlarmItem
+	}
+
+	realtimeAlarmBuilder struct {
+		alarm *bizmodel.RealtimeAlarm
+		ctx   context.Context
+	}
+)
+
+func (r *realtimeAlarmBuilder) ToAPI() *adminapi.RealtimeAlarmItem {
+	if types.IsNil(r) || types.IsNil(r.alarm) {
+		return nil
+	}
+	detail := r.alarm
+	return &adminapi.RealtimeAlarmItem{
+		Id:           detail.ID,
+		StartsAt:     types.NewTimeByUnix(detail.StartsAt).String(),
+		EndsAt:       types.NewTimeByUnix(detail.EndsAt).String(),
+		Status:       api.AlertStatus(detail.Status),
+		Level:        NewBuilder().WithDict(detail.Level).ToAPISelect(),
+		LevelID:      detail.LevelID,
+		StrategyID:   detail.StrategyID,
+		Strategy:     NewBuilder().WithContext(r.ctx).WithAPIStrategy(detail.Strategy).ToAPI(),
+		Summary:      detail.Summary,
+		Description:  detail.Description,
+		Expr:         detail.Expr,
+		DatasourceID: detail.DatasourceID,
+		Datasource:   NewBuilder().WithDoDatasource(detail.Datasource).ToAPI(),
+		Fingerprint:  detail.Fingerprint,
+	}
+}
+
+func NewRealtimeAlarmBuilder(ctx context.Context, alarm *bizmodel.RealtimeAlarm) RealtimeAlarmBuilder {
+	return &realtimeAlarmBuilder{alarm: alarm, ctx: ctx}
+}

--- a/cmd/server/palace/internal/service/build/builder.go
+++ b/cmd/server/palace/internal/service/build/builder.go
@@ -86,8 +86,13 @@ type (
 		WithAPIDatasourceMetricLabelValue(metric *bizmodel.MetricLabelValue) DatasourceMetricLabelValueBuilder
 
 		WithRealTimeAlarm(alarm *bizmodel.RealtimeAlarm) RealtimeAlarmBuilder
+		DashboardModule() DashboardModuleBuilder
 	}
 )
+
+func (b *builder) DashboardModule() DashboardModuleBuilder {
+	return NewDashboardModuleBuilder(b.ctx)
+}
 
 func (b *builder) WithRealTimeAlarm(alarm *bizmodel.RealtimeAlarm) RealtimeAlarmBuilder {
 	return NewRealtimeAlarmBuilder(b.ctx, alarm)

--- a/cmd/server/palace/internal/service/build/builder.go
+++ b/cmd/server/palace/internal/service/build/builder.go
@@ -85,7 +85,7 @@ type (
 		WithAPIDatasourceMetricLabel(metric *bizmodel.MetricLabel) DatasourceMetricLabelModelBuilder
 		WithAPIDatasourceMetricLabelValue(metric *bizmodel.MetricLabelValue) DatasourceMetricLabelValueBuilder
 
-		WithRealTimeAlarm(alarm *bizmodel.RealtimeAlarm) RealtimeAlarmBuilder
+		RealTimeAlarmModule() RealtimeAlarmModuleBuilder
 		DashboardModule() DashboardModuleBuilder
 	}
 )
@@ -94,8 +94,8 @@ func (b *builder) DashboardModule() DashboardModuleBuilder {
 	return NewDashboardModuleBuilder(b.ctx)
 }
 
-func (b *builder) WithRealTimeAlarm(alarm *bizmodel.RealtimeAlarm) RealtimeAlarmBuilder {
-	return NewRealtimeAlarmBuilder(b.ctx, alarm)
+func (b *builder) RealTimeAlarmModule() RealtimeAlarmModuleBuilder {
+	return newRealtimeAlarmModuleBuilder(b.ctx)
 }
 
 func (b *builder) WithDict(dict imodel.IDict) DictModelBuilder {

--- a/cmd/server/palace/internal/service/build/builder.go
+++ b/cmd/server/palace/internal/service/build/builder.go
@@ -84,8 +84,14 @@ type (
 
 		WithAPIDatasourceMetricLabel(metric *bizmodel.MetricLabel) DatasourceMetricLabelModelBuilder
 		WithAPIDatasourceMetricLabelValue(metric *bizmodel.MetricLabelValue) DatasourceMetricLabelValueBuilder
+
+		WithRealTimeAlarm(alarm *bizmodel.RealtimeAlarm) RealtimeAlarmBuilder
 	}
 )
+
+func (b *builder) WithRealTimeAlarm(alarm *bizmodel.RealtimeAlarm) RealtimeAlarmBuilder {
+	return NewRealtimeAlarmBuilder(b.ctx, alarm)
+}
 
 func (b *builder) WithDict(dict imodel.IDict) DictModelBuilder {
 	return &dictBuilder{

--- a/cmd/server/palace/internal/service/build/dashboard.go
+++ b/cmd/server/palace/internal/service/build/dashboard.go
@@ -1,0 +1,59 @@
+package build
+
+import (
+	adminapi "github.com/aide-family/moon/api/admin"
+	realtimeapi "github.com/aide-family/moon/api/admin/realtime"
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+)
+
+type (
+	// ChartItemBuilder bo 图表构造器
+	ChartItemBuilder interface {
+		ToBo() *bo.ChartItem
+	}
+
+	// BoAddDashboardParamsBuilder 添加仪表盘参数构造器
+	BoAddDashboardParamsBuilder interface {
+		ToBo() *bo.AddDashboardParams
+	}
+
+	// BoUpdateDashboardParamsBuilder 更新仪表盘参数构造器
+	BoUpdateDashboardParamsBuilder interface {
+		ToBo() *bo.UpdateDashboardParams
+	}
+
+	// BoDeleteDashboardParamsBuilder 删除仪表盘参数构造器
+	BoDeleteDashboardParamsBuilder interface {
+		ToBo() *bo.DeleteDashboardParams
+	}
+
+	// BoListDashboardParams 列表构造器
+	BoListDashboardParams interface {
+		ToBo() *bo.ListDashboardParams
+	}
+
+	// DoDashboardBuilder 仪表盘构造器
+	DoDashboardBuilder interface {
+		ToAPI() *adminapi.DashboardItem
+		ToSelect() *adminapi.SelectItem
+	}
+
+	// DoDashboardListBuilder 仪表盘列表构造器
+	DoDashboardListBuilder interface {
+		ToAPIs() []*adminapi.DashboardItem
+		ToSelects() []*adminapi.SelectItem
+	}
+
+	// DashboardModuleBuilder 仪表盘模块构造器
+	DashboardModuleBuilder interface {
+		WithBoChart(*adminapi.ChartItem) ChartItemBuilder
+		WithAddDashboardParams(*realtimeapi.CreateDashboardRequest) BoAddDashboardParamsBuilder
+		WithUpdateDashboardParams(*realtimeapi.UpdateDashboardRequest) BoUpdateDashboardParamsBuilder
+		WithDeleteDashboardParams(*realtimeapi.DeleteDashboardRequest) BoDeleteDashboardParamsBuilder
+		WithQueryDashboardListParams(*realtimeapi.ListDashboardRequest) BoListDashboardParams
+		WithQueryDashboardSelectParams(*realtimeapi.ListDashboardSelectRequest) BoListDashboardParams
+		WithDoDashboard(*bizmodel.Dashboard) DoDashboardBuilder
+		WithDoDashboardList([]*bizmodel.Dashboard) DoDashboardListBuilder
+	}
+)

--- a/cmd/server/palace/internal/service/build/dashboard.go
+++ b/cmd/server/palace/internal/service/build/dashboard.go
@@ -1,35 +1,125 @@
 package build
 
 import (
+	"context"
+
+	"github.com/aide-family/moon/api"
 	adminapi "github.com/aide-family/moon/api/admin"
 	realtimeapi "github.com/aide-family/moon/api/admin/realtime"
 	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
+	"github.com/aide-family/moon/pkg/palace/model"
 	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+	"github.com/aide-family/moon/pkg/util/types"
+	"github.com/aide-family/moon/pkg/vobj"
 )
 
+// NewDashboardModuleBuilder 创建仪表盘模块构造器
+func NewDashboardModuleBuilder(ctx context.Context) DashboardModuleBuilder {
+	return &dashboardModuleBuilder{ctx: ctx}
+}
+
+func newAPIChartItemBuilder(ctx context.Context, item *adminapi.ChartItem) APIChartItemBuilder {
+	return &apiChartItemBuilder{ctx: ctx, item: item}
+}
+
+func newAPIsChartItemBuilder(ctx context.Context, items []*adminapi.ChartItem) APIsChartItemBuilder {
+	return &apisChartItemBuilder{ctx: ctx, items: items}
+}
+
+func newDoChartsBuilder(ctx context.Context, item *bizmodel.DashboardChart) DoChartBuilder {
+	return &doChartBuilder{ctx: ctx, item: item}
+}
+
+func newDosChartsBuilder(ctx context.Context, items []*bizmodel.DashboardChart) DosChartBuilder {
+	return &dosChartBuilder{ctx: ctx, items: items}
+}
+
+func newDoDashboardBuilder(ctx context.Context, item *bizmodel.Dashboard) DoDashboardBuilder {
+	return &doDashboardBuilder{ctx: ctx, item: item}
+}
+
+func newDosDashboardBuilder(ctx context.Context, items []*bizmodel.Dashboard) DosDashboardBuilder {
+	return &dosDashboardBuilder{ctx: ctx, items: items}
+}
+
+func newBoAddDashboardParamsBuilder(ctx context.Context, params *bo.AddDashboardParams) BoAddDashboardParamsBuilder {
+	return &boAddDashboardParamsBuilder{ctx: ctx, params: params}
+}
+
+func newBoChartItemBuilder(ctx context.Context, item *bo.ChartItem) BoChartItemBuilder {
+	return &boChartItemBuilder{ctx: ctx, item: item}
+}
+
+func newBosChartItemBuilder(ctx context.Context, items []*bo.ChartItem) BosChartItemBuilder {
+	return &bosChartItemBuilder{ctx: ctx, items: items}
+}
+
+func newBoUpdateDashboardParamsBuilder(ctx context.Context, params *bo.UpdateDashboardParams) BoUpdateDashboardParamsBuilder {
+	return &boUpdateDashboardParamsBuilder{ctx: ctx, params: params}
+}
+
+func newAPIDeleteDashboardParamsBuilder(ctx context.Context, params *realtimeapi.DeleteDashboardRequest) APIDeleteDashboardParamsBuilder {
+	return &apiDeleteDashboardParamsBuilder{ctx: ctx, params: params}
+}
+
+func newAPIDashboardListParamsBuilder(ctx context.Context, params *realtimeapi.ListDashboardRequest) APIListDashboardParams {
+	return &apiListDashboardParams{ctx: ctx, params: params}
+}
+
+func newAPIDashboardSelectParamsBuilder(ctx context.Context, params *realtimeapi.ListDashboardSelectRequest) APIListDashboardParams {
+	return &apiListDashboardSelectParams{ctx: ctx, params: params}
+}
+
+func newAPIUpdateDashboardParamsBuilder(ctx context.Context, params *realtimeapi.UpdateDashboardRequest) APIUpdateDashboardParamsBuilder {
+	return &apiUpdateDashboardParamsBuilder{ctx: ctx, params: params}
+}
+
+func newAPIAddDashboardParamsBuilder(ctx context.Context, params *realtimeapi.CreateDashboardRequest) APIAddDashboardParamsBuilder {
+	return &apiAddDashboardParamsBuilder{ctx: ctx, params: params}
+}
+
 type (
-	// ChartItemBuilder bo 图表构造器
-	ChartItemBuilder interface {
+	// APIChartItemBuilder bo 图表构造器
+	APIChartItemBuilder interface {
 		ToBo() *bo.ChartItem
+		WithDashboardID(uint32) APIChartItemBuilder
 	}
 
-	// BoAddDashboardParamsBuilder 添加仪表盘参数构造器
-	BoAddDashboardParamsBuilder interface {
+	// APIsChartItemBuilder 图表构造器
+	APIsChartItemBuilder interface {
+		ToBos() []*bo.ChartItem
+		WithDashboardID(uint32) APIsChartItemBuilder
+	}
+
+	// BoChartItemBuilder 图表构造器
+	BoChartItemBuilder interface {
+		WithDashboardID(uint32) BoChartItemBuilder
+		ToDo() *bizmodel.DashboardChart
+	}
+
+	// BosChartItemBuilder 图表构造器
+	BosChartItemBuilder interface {
+		WithDashboardID(uint32) BosChartItemBuilder
+		ToDos() []*bizmodel.DashboardChart
+	}
+
+	// APIAddDashboardParamsBuilder 添加仪表盘参数构造器
+	APIAddDashboardParamsBuilder interface {
 		ToBo() *bo.AddDashboardParams
 	}
 
-	// BoUpdateDashboardParamsBuilder 更新仪表盘参数构造器
-	BoUpdateDashboardParamsBuilder interface {
+	// APIUpdateDashboardParamsBuilder 更新仪表盘参数构造器
+	APIUpdateDashboardParamsBuilder interface {
 		ToBo() *bo.UpdateDashboardParams
 	}
 
-	// BoDeleteDashboardParamsBuilder 删除仪表盘参数构造器
-	BoDeleteDashboardParamsBuilder interface {
+	// APIDeleteDashboardParamsBuilder 删除仪表盘参数构造器
+	APIDeleteDashboardParamsBuilder interface {
 		ToBo() *bo.DeleteDashboardParams
 	}
 
-	// BoListDashboardParams 列表构造器
-	BoListDashboardParams interface {
+	// APIListDashboardParams 列表构造器
+	APIListDashboardParams interface {
 		ToBo() *bo.ListDashboardParams
 	}
 
@@ -39,21 +129,538 @@ type (
 		ToSelect() *adminapi.SelectItem
 	}
 
-	// DoDashboardListBuilder 仪表盘列表构造器
-	DoDashboardListBuilder interface {
+	// DosDashboardBuilder 仪表盘列表构造器
+	DosDashboardBuilder interface {
 		ToAPIs() []*adminapi.DashboardItem
 		ToSelects() []*adminapi.SelectItem
 	}
 
+	// BoAddDashboardParamsBuilder 添加仪表盘参数构造器
+	BoAddDashboardParamsBuilder interface {
+		ToDo() *bizmodel.Dashboard
+		ToDoCharts() []*bizmodel.DashboardChart
+		ToDoStrategyGroups() []*bizmodel.StrategyGroup
+		WithDashboardID(uint32) BoAddDashboardParamsBuilder
+	}
+
+	// BoUpdateDashboardParamsBuilder 更新仪表盘参数构造器
+	BoUpdateDashboardParamsBuilder interface {
+		ToDo() *bizmodel.Dashboard
+		ToDoCharts() []*bizmodel.DashboardChart
+		ToDoStrategyGroups() []*bizmodel.StrategyGroup
+		WithDashboardID(uint32) BoUpdateDashboardParamsBuilder
+	}
+
+	// DosChartBuilder 图表构造器
+	DosChartBuilder interface {
+		ToAPIs() []*adminapi.ChartItem
+		ToSelects() []*adminapi.SelectItem
+	}
+
+	// DoChartBuilder 图表构造器
+	DoChartBuilder interface {
+		ToAPI() *adminapi.ChartItem
+		ToSelect() *adminapi.SelectItem
+	}
+
 	// DashboardModuleBuilder 仪表盘模块构造器
 	DashboardModuleBuilder interface {
-		WithBoChart(*adminapi.ChartItem) ChartItemBuilder
-		WithAddDashboardParams(*realtimeapi.CreateDashboardRequest) BoAddDashboardParamsBuilder
-		WithUpdateDashboardParams(*realtimeapi.UpdateDashboardRequest) BoUpdateDashboardParamsBuilder
-		WithDeleteDashboardParams(*realtimeapi.DeleteDashboardRequest) BoDeleteDashboardParamsBuilder
-		WithQueryDashboardListParams(*realtimeapi.ListDashboardRequest) BoListDashboardParams
-		WithQueryDashboardSelectParams(*realtimeapi.ListDashboardSelectRequest) BoListDashboardParams
+		WithAPIChart(*adminapi.ChartItem) APIChartItemBuilder
+		WithAPIsChart(items []*adminapi.ChartItem) APIsChartItemBuilder
+		WithAPIAddDashboardParams(*realtimeapi.CreateDashboardRequest) APIAddDashboardParamsBuilder
+		WithAPIUpdateDashboardParams(*realtimeapi.UpdateDashboardRequest) APIUpdateDashboardParamsBuilder
+		WithAPIDeleteDashboardParams(*realtimeapi.DeleteDashboardRequest) APIDeleteDashboardParamsBuilder
+		WithAPIQueryDashboardListParams(*realtimeapi.ListDashboardRequest) APIListDashboardParams
+		WithAPIQueryDashboardSelectParams(*realtimeapi.ListDashboardSelectRequest) APIListDashboardParams
 		WithDoDashboard(*bizmodel.Dashboard) DoDashboardBuilder
-		WithDoDashboardList([]*bizmodel.Dashboard) DoDashboardListBuilder
+		WithDoDashboardList([]*bizmodel.Dashboard) DosDashboardBuilder
+		WithBoAddDashboardParams(*bo.AddDashboardParams) BoAddDashboardParamsBuilder
+		WithBoUpdateDashboardParams(*bo.UpdateDashboardParams) BoUpdateDashboardParamsBuilder
+		WithBoChart(*bo.ChartItem) BoChartItemBuilder
+		WithBosChart([]*bo.ChartItem) BosChartItemBuilder
+		WithDosChart([]*bizmodel.DashboardChart) DosChartBuilder
+		WithDoChart(*bizmodel.DashboardChart) DoChartBuilder
+	}
+
+	dashboardModuleBuilder struct {
+		ctx context.Context
+	}
+
+	apiChartItemBuilder struct {
+		ctx         context.Context
+		item        *adminapi.ChartItem
+		dashboardID uint32
+	}
+
+	apisChartItemBuilder struct {
+		ctx         context.Context
+		items       []*adminapi.ChartItem
+		dashboardID uint32
+	}
+
+	apiAddDashboardParamsBuilder struct {
+		ctx    context.Context
+		params *realtimeapi.CreateDashboardRequest
+	}
+
+	apiUpdateDashboardParamsBuilder struct {
+		ctx    context.Context
+		params *realtimeapi.UpdateDashboardRequest
+	}
+
+	apiDeleteDashboardParamsBuilder struct {
+		ctx    context.Context
+		params *realtimeapi.DeleteDashboardRequest
+	}
+
+	apiListDashboardParams struct {
+		ctx    context.Context
+		params *realtimeapi.ListDashboardRequest
+	}
+
+	apiListDashboardSelectParams struct {
+		ctx    context.Context
+		params *realtimeapi.ListDashboardSelectRequest
+	}
+
+	doDashboardBuilder struct {
+		ctx  context.Context
+		item *bizmodel.Dashboard
+	}
+
+	dosDashboardBuilder struct {
+		ctx   context.Context
+		items []*bizmodel.Dashboard
+	}
+
+	dosChartBuilder struct {
+		ctx   context.Context
+		items []*bizmodel.DashboardChart
+	}
+
+	doChartBuilder struct {
+		ctx  context.Context
+		item *bizmodel.DashboardChart
+	}
+
+	boAddDashboardParamsBuilder struct {
+		ctx         context.Context
+		params      *bo.AddDashboardParams
+		dashboardID uint32
+	}
+
+	boUpdateDashboardParamsBuilder struct {
+		ctx         context.Context
+		params      *bo.UpdateDashboardParams
+		dashboardID uint32
+	}
+
+	boChartItemBuilder struct {
+		ctx         context.Context
+		item        *bo.ChartItem
+		dashboardID uint32
+	}
+
+	bosChartItemBuilder struct {
+		ctx         context.Context
+		items       []*bo.ChartItem
+		dashboardID uint32
 	}
 )
+
+func (b *boUpdateDashboardParamsBuilder) ToDo() *bizmodel.Dashboard {
+	if types.IsNil(b) || types.IsNil(b.params) {
+		return nil
+	}
+	params := b.params
+	return &bizmodel.Dashboard{
+		AllFieldModel: model.AllFieldModel{
+			ID: params.ID,
+		},
+		Name:           params.Name,
+		Remark:         params.Remark,
+		Status:         params.Status,
+		Color:          b.params.Color,
+		Charts:         b.ToDoCharts(),
+		StrategyGroups: b.ToDoStrategyGroups(),
+	}
+}
+
+func (b *boUpdateDashboardParamsBuilder) ToDoCharts() []*bizmodel.DashboardChart {
+	if types.IsNil(b) || types.IsNil(b.params) {
+		return nil
+	}
+	return newBosChartItemBuilder(b.ctx, b.params.Charts).WithDashboardID(b.dashboardID).ToDos()
+}
+
+func (b *boUpdateDashboardParamsBuilder) ToDoStrategyGroups() []*bizmodel.StrategyGroup {
+	if types.IsNil(b) || types.IsNil(b.params) {
+		return nil
+	}
+	return types.SliceTo(b.params.StrategyGroups, func(item uint32) *bizmodel.StrategyGroup {
+		return &bizmodel.StrategyGroup{AllFieldModel: model.AllFieldModel{ID: item}}
+	})
+}
+
+func (b *boUpdateDashboardParamsBuilder) WithDashboardID(dashboardID uint32) BoUpdateDashboardParamsBuilder {
+	if types.IsNil(b) || types.IsNil(b.params) {
+		return newBoUpdateDashboardParamsBuilder(b.ctx, nil).WithDashboardID(dashboardID)
+	}
+	b.dashboardID = dashboardID
+	return b
+}
+
+func (b *bosChartItemBuilder) WithDashboardID(dashboardID uint32) BosChartItemBuilder {
+	if types.IsNil(b) || types.IsNil(b.items) {
+		return newBosChartItemBuilder(b.ctx, nil).WithDashboardID(dashboardID)
+	}
+	b.dashboardID = dashboardID
+	return b
+}
+
+func (b *bosChartItemBuilder) ToDos() []*bizmodel.DashboardChart {
+	if types.IsNil(b) || types.IsNil(b.items) {
+		return nil
+	}
+	items := b.items
+	return types.SliceTo(items, func(item *bo.ChartItem) *bizmodel.DashboardChart {
+		return newBoChartItemBuilder(b.ctx, item).WithDashboardID(b.dashboardID).ToDo()
+	})
+}
+
+func (b *boChartItemBuilder) WithDashboardID(dashboardID uint32) BoChartItemBuilder {
+	if types.IsNil(b) || types.IsNil(b.item) {
+		return newBoChartItemBuilder(b.ctx, nil).WithDashboardID(dashboardID)
+	}
+	b.dashboardID = dashboardID
+	return b
+}
+
+func (b *boChartItemBuilder) ToDo() *bizmodel.DashboardChart {
+	if types.IsNil(b) || types.IsNil(b.item) {
+		return nil
+	}
+	item := b.item
+	return &bizmodel.DashboardChart{
+		AllFieldModel: model.AllFieldModel{ID: item.ID},
+		Name:          item.Name,
+		Status:        item.Status,
+		Remark:        item.Remark,
+		URL:           item.URL,
+		DashboardID:   b.dashboardID,
+		ChartType:     item.ChartType,
+		Width:         item.Width,
+		Height:        item.Height,
+	}
+}
+
+func (b *boAddDashboardParamsBuilder) ToDo() *bizmodel.Dashboard {
+	if types.IsNil(b) || types.IsNil(b.params) {
+		return nil
+	}
+	params := b.params
+	return &bizmodel.Dashboard{
+		Name:           params.Name,
+		Status:         vobj.StatusEnable,
+		Remark:         params.Remark,
+		Color:          params.Color,
+		Charts:         b.ToDoCharts(),
+		StrategyGroups: b.ToDoStrategyGroups(),
+	}
+}
+
+func (b *boAddDashboardParamsBuilder) ToDoCharts() []*bizmodel.DashboardChart {
+	if types.IsNil(b) || types.IsNil(b.params) {
+		return nil
+	}
+	return newBosChartItemBuilder(b.ctx, b.params.Charts).ToDos()
+}
+
+func (b *boAddDashboardParamsBuilder) ToDoStrategyGroups() []*bizmodel.StrategyGroup {
+	if types.IsNil(b) || types.IsNil(b.params) {
+		return nil
+	}
+	return types.SliceTo(b.params.StrategyGroups, func(item uint32) *bizmodel.StrategyGroup {
+		return &bizmodel.StrategyGroup{
+			AllFieldModel: model.AllFieldModel{ID: item},
+		}
+	})
+}
+
+func (b *boAddDashboardParamsBuilder) WithDashboardID(dashboardID uint32) BoAddDashboardParamsBuilder {
+	if types.IsNil(b) {
+		return newBoAddDashboardParamsBuilder(context.TODO(), nil).WithDashboardID(dashboardID)
+	}
+	b.dashboardID = dashboardID
+	return b
+}
+
+func (d *dosDashboardBuilder) ToAPIs() []*adminapi.DashboardItem {
+	if types.IsNil(d) || types.IsNil(d.items) {
+		return nil
+	}
+	return types.SliceTo(d.items, func(item *bizmodel.Dashboard) *adminapi.DashboardItem {
+		return newDoDashboardBuilder(d.ctx, item).ToAPI()
+	})
+}
+
+func (d *dosDashboardBuilder) ToSelects() []*adminapi.SelectItem {
+	if types.IsNil(d) || types.IsNil(d.items) {
+		return nil
+	}
+	return types.SliceTo(d.items, func(item *bizmodel.Dashboard) *adminapi.SelectItem {
+		return newDoDashboardBuilder(d.ctx, item).ToSelect()
+	})
+}
+
+func (d *dosChartBuilder) ToAPIs() []*adminapi.ChartItem {
+	if types.IsNil(d) || types.IsNil(d.items) {
+		return nil
+	}
+	items := d.items
+	return types.SliceTo(items, func(item *bizmodel.DashboardChart) *adminapi.ChartItem {
+		return newDoChartsBuilder(d.ctx, item).ToAPI()
+	})
+}
+
+func (d *dosChartBuilder) ToSelects() []*adminapi.SelectItem {
+	if types.IsNil(d) || types.IsNil(d.items) {
+		return nil
+	}
+	items := d.items
+	return types.SliceTo(items, func(item *bizmodel.DashboardChart) *adminapi.SelectItem {
+		return newDoChartsBuilder(d.ctx, item).ToSelect()
+	})
+}
+
+func (d *doChartBuilder) ToAPI() *adminapi.ChartItem {
+	if types.IsNil(d) || types.IsNil(d.item) {
+		return nil
+	}
+
+	item := d.item
+	return &adminapi.ChartItem{
+		Id:        item.ID,
+		Title:     item.Name,
+		Remark:    item.Remark,
+		Url:       item.URL,
+		Status:    api.Status(item.Status),
+		ChartType: api.ChartType(item.ChartType),
+		Width:     item.Width,
+		Height:    item.Height,
+	}
+}
+
+func (d *doChartBuilder) ToSelect() *adminapi.SelectItem {
+	if types.IsNil(d) || types.IsNil(d.item) {
+		return nil
+	}
+	item := d.item
+	return &adminapi.SelectItem{
+		Value:    item.ID,
+		Label:    item.Name,
+		Children: nil,
+		Disabled: item.DeletedAt > 0 || !item.Status.IsEnable(),
+		Extend:   nil,
+	}
+}
+
+func (d *dashboardModuleBuilder) WithDosChart(charts []*bizmodel.DashboardChart) DosChartBuilder {
+	return &dosChartBuilder{ctx: d.ctx, items: charts}
+}
+
+func (d *dashboardModuleBuilder) WithDoChart(chart *bizmodel.DashboardChart) DoChartBuilder {
+	return &doChartBuilder{ctx: d.ctx, item: chart}
+}
+
+func (d *doDashboardBuilder) ToAPI() *adminapi.DashboardItem {
+	if types.IsNil(d) || types.IsNil(d.item) {
+		return nil
+	}
+	item := d.item
+	return &adminapi.DashboardItem{
+		Id:        item.ID,
+		Title:     item.Name,
+		Remark:    item.Remark,
+		CreatedAt: item.CreatedAt.String(),
+		UpdatedAt: item.UpdatedAt.String(),
+		DeletedAt: types.NewTimeByUnix(int64(item.DeletedAt)).String(),
+		Color:     item.Color,
+		Charts:    newDosChartsBuilder(d.ctx, item.Charts).ToAPIs(),
+		Status:    api.Status(item.Status),
+		Groups:    nil, // TODO 等builder重构完一起替换
+	}
+}
+
+func (d *doDashboardBuilder) ToSelect() *adminapi.SelectItem {
+	if types.IsNil(d) || types.IsNil(d.item) {
+		return nil
+	}
+	item := d.item
+	return &adminapi.SelectItem{
+		Value:    item.ID,
+		Label:    item.Name,
+		Children: nil,
+		Disabled: item.DeletedAt > 9 || !item.Status.IsEnable(),
+		Extend:   nil,
+	}
+}
+
+func (a *apiListDashboardSelectParams) ToBo() *bo.ListDashboardParams {
+	if types.IsNil(a) || types.IsNil(a.params) {
+		return nil
+	}
+	params := a.params
+	return &bo.ListDashboardParams{
+		Page:    types.NewPagination(params.GetPagination()),
+		Keyword: params.GetKeyword(),
+		Status:  vobj.Status(params.GetStatus()),
+	}
+}
+
+func (a *apiListDashboardParams) ToBo() *bo.ListDashboardParams {
+	if types.IsNil(a) || types.IsNil(a.params) {
+		return nil
+	}
+	params := a.params
+	return &bo.ListDashboardParams{
+		Page:    types.NewPagination(params.GetPagination()),
+		Keyword: params.GetKeyword(),
+		Status:  vobj.Status(params.GetStatus()),
+	}
+}
+
+func (a *apiDeleteDashboardParamsBuilder) ToBo() *bo.DeleteDashboardParams {
+	if types.IsNil(a) || types.IsNil(a.params) {
+		return nil
+	}
+	params := a.params
+	return &bo.DeleteDashboardParams{
+		ID:     params.GetId(),
+		Status: vobj.StatusDisable, // 只允许删除禁用状态的仪表盘
+	}
+}
+
+func (a *apiUpdateDashboardParamsBuilder) ToBo() *bo.UpdateDashboardParams {
+	if types.IsNil(a) || types.IsNil(a.params) {
+		return nil
+	}
+	params := a.params
+	return &bo.UpdateDashboardParams{
+		ID:             params.GetId(),
+		Name:           params.GetTitle(),
+		Remark:         params.GetRemark(),
+		Color:          params.GetColor(),
+		Charts:         newAPIsChartItemBuilder(a.ctx, params.GetCharts()).WithDashboardID(params.GetId()).ToBos(),
+		StrategyGroups: params.GetStrategyGroups(),
+	}
+}
+
+func (a *apiAddDashboardParamsBuilder) ToBo() *bo.AddDashboardParams {
+	if types.IsNil(a) || types.IsNil(a.params) {
+		return nil
+	}
+	params := a.params
+	return &bo.AddDashboardParams{
+		Name:           params.GetTitle(),
+		Remark:         params.GetRemark(),
+		Color:          params.GetColor(),
+		Charts:         newAPIsChartItemBuilder(a.ctx, params.GetCharts()).ToBos(),
+		StrategyGroups: params.GetStrategyGroups(),
+	}
+}
+
+func (a *apisChartItemBuilder) ToBos() []*bo.ChartItem {
+	if types.IsNil(a) {
+		return nil
+	}
+	return types.SliceTo(a.items, func(item *adminapi.ChartItem) *bo.ChartItem {
+		return newAPIChartItemBuilder(a.ctx, item).WithDashboardID(a.dashboardID).ToBo()
+	})
+}
+
+func (a *apisChartItemBuilder) WithDashboardID(dashboardID uint32) APIsChartItemBuilder {
+	if types.IsNil(a) {
+		return &apisChartItemBuilder{ctx: context.TODO()}
+	}
+	a.dashboardID = dashboardID
+	return a
+}
+
+func (a *apiChartItemBuilder) ToBo() *bo.ChartItem {
+	if types.IsNil(a) || types.IsNil(a.item) {
+		return nil
+	}
+	item := a.item
+	return &bo.ChartItem{
+		ID:          item.GetId(),
+		Name:        item.GetTitle(),
+		Remark:      item.GetRemark(),
+		URL:         item.GetUrl(),
+		Status:      vobj.Status(item.GetStatus()),
+		Height:      item.GetHeight(),
+		Width:       item.GetWidth(),
+		ChartType:   vobj.DashboardChartType(a.item.ChartType),
+		DashboardID: a.dashboardID,
+	}
+}
+
+func (a *apiChartItemBuilder) WithDashboardID(dashboardID uint32) APIChartItemBuilder {
+	if types.IsNil(a) {
+		return &apiChartItemBuilder{ctx: context.TODO()}
+	}
+	a.dashboardID = dashboardID
+	return a
+}
+
+func (d *dashboardModuleBuilder) WithAPIChart(item *adminapi.ChartItem) APIChartItemBuilder {
+	return newAPIChartItemBuilder(d.ctx, item)
+}
+
+func (d *dashboardModuleBuilder) WithAPIsChart(items []*adminapi.ChartItem) APIsChartItemBuilder {
+	return newAPIsChartItemBuilder(d.ctx, items)
+}
+
+func (d *dashboardModuleBuilder) WithAPIAddDashboardParams(request *realtimeapi.CreateDashboardRequest) APIAddDashboardParamsBuilder {
+	return newAPIAddDashboardParamsBuilder(d.ctx, request)
+}
+
+func (d *dashboardModuleBuilder) WithAPIUpdateDashboardParams(request *realtimeapi.UpdateDashboardRequest) APIUpdateDashboardParamsBuilder {
+	return newAPIUpdateDashboardParamsBuilder(d.ctx, request)
+}
+
+func (d *dashboardModuleBuilder) WithAPIDeleteDashboardParams(request *realtimeapi.DeleteDashboardRequest) APIDeleteDashboardParamsBuilder {
+	return newAPIDeleteDashboardParamsBuilder(d.ctx, request)
+}
+
+func (d *dashboardModuleBuilder) WithAPIQueryDashboardListParams(request *realtimeapi.ListDashboardRequest) APIListDashboardParams {
+	return newAPIDashboardListParamsBuilder(d.ctx, request)
+}
+
+func (d *dashboardModuleBuilder) WithAPIQueryDashboardSelectParams(request *realtimeapi.ListDashboardSelectRequest) APIListDashboardParams {
+	return newAPIDashboardSelectParamsBuilder(d.ctx, request)
+}
+
+func (d *dashboardModuleBuilder) WithDoDashboard(dashboard *bizmodel.Dashboard) DoDashboardBuilder {
+	return newDoDashboardBuilder(d.ctx, dashboard)
+}
+
+func (d *dashboardModuleBuilder) WithDoDashboardList(dashboards []*bizmodel.Dashboard) DosDashboardBuilder {
+	return newDosDashboardBuilder(d.ctx, dashboards)
+}
+
+func (d *dashboardModuleBuilder) WithBoAddDashboardParams(params *bo.AddDashboardParams) BoAddDashboardParamsBuilder {
+	return newBoAddDashboardParamsBuilder(d.ctx, params)
+}
+
+func (d *dashboardModuleBuilder) WithBoUpdateDashboardParams(params *bo.UpdateDashboardParams) BoUpdateDashboardParamsBuilder {
+	return newBoUpdateDashboardParamsBuilder(d.ctx, params)
+}
+
+func (d *dashboardModuleBuilder) WithBoChart(item *bo.ChartItem) BoChartItemBuilder {
+	return newBoChartItemBuilder(d.ctx, item)
+}
+
+func (d *dashboardModuleBuilder) WithBosChart(items []*bo.ChartItem) BosChartItemBuilder {
+	return newBosChartItemBuilder(d.ctx, items)
+}

--- a/cmd/server/palace/internal/service/build/strategy.go
+++ b/cmd/server/palace/internal/service/build/strategy.go
@@ -16,7 +16,7 @@ import (
 type (
 	// StrategyModelBuilder 策略模型构建器
 	StrategyModelBuilder interface {
-		ToAPI(ctx context.Context) *admin.StrategyItem
+		ToAPI() *admin.StrategyItem
 	}
 
 	// StrategyRequestBuilder 策略请求构建器
@@ -77,7 +77,7 @@ type (
 )
 
 // ToAPI 转换为API层数据
-func (b *strategyBuilder) ToAPI(ctx context.Context) *admin.StrategyItem {
+func (b *strategyBuilder) ToAPI() *admin.StrategyItem {
 	if types.IsNil(b) || types.IsNil(b.Strategy) {
 		return nil
 	}
@@ -92,7 +92,7 @@ func (b *strategyBuilder) ToAPI(ctx context.Context) *admin.StrategyItem {
 		Labels:      b.Strategy.Labels.Map(),
 		Annotations: b.Strategy.Annotations,
 		Datasource: types.SliceTo(b.Strategy.Datasource, func(datasource *bizmodel.Datasource) *admin.DatasourceItem {
-			return NewBuilder().WithContext(ctx).WithDoDatasource(datasource).ToAPI()
+			return NewBuilder().WithContext(b.ctx).WithDoDatasource(datasource).ToAPI()
 		}),
 		StrategyTemplateId: b.Strategy.StrategyTemplateID,
 		Levels:             strategyLevels,

--- a/cmd/server/palace/internal/service/realtime/alarm.go
+++ b/cmd/server/palace/internal/service/realtime/alarm.go
@@ -3,25 +3,64 @@ package realtime
 import (
 	"context"
 
+	"github.com/aide-family/moon/api"
+	adminapi "github.com/aide-family/moon/api/admin"
 	pb "github.com/aide-family/moon/api/admin/realtime"
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz"
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz/bo"
+	"github.com/aide-family/moon/cmd/server/palace/internal/service/build"
+	"github.com/aide-family/moon/pkg/palace/model/bizmodel"
+	"github.com/aide-family/moon/pkg/util/types"
+	"github.com/aide-family/moon/pkg/vobj"
 )
 
 // AlarmService 实时告警数据服务
 type AlarmService struct {
 	pb.UnimplementedAlarmServer
+
+	alarmBiz *biz.AlarmBiz
 }
 
 // NewAlarmService 实时告警数据服务
-func NewAlarmService() *AlarmService {
-	return &AlarmService{}
+func NewAlarmService(alarmBiz *biz.AlarmBiz) *AlarmService {
+	return &AlarmService{
+		alarmBiz: alarmBiz,
+	}
 }
 
 // GetAlarm 获取实时告警数据
 func (s *AlarmService) GetAlarm(ctx context.Context, req *pb.GetAlarmRequest) (*pb.GetAlarmReply, error) {
-	return &pb.GetAlarmReply{}, nil
+	realtimeAlarmDetail, err := s.alarmBiz.GetRealTimeAlarm(ctx, &bo.GetRealTimeAlarmParams{
+		RealtimeAlarmID: req.GetId(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &pb.GetAlarmReply{
+		Detail: build.NewBuilder().WithContext(ctx).WithRealTimeAlarm(realtimeAlarmDetail).ToAPI(),
+	}, nil
 }
 
 // ListAlarm 获取实时告警数据列表
 func (s *AlarmService) ListAlarm(ctx context.Context, req *pb.ListAlarmRequest) (*pb.ListAlarmReply, error) {
-	return &pb.ListAlarmReply{}, nil
+	params := &bo.GetRealTimeAlarmsParams{
+		Pagination:      types.NewPagination(req.GetPagination()),
+		EventAtStart:    req.GetEventAtStart(),
+		EventAtEnd:      req.GetEventAtEnd(),
+		ResolvedAtStart: req.GetRecoverAtStart(),
+		ResolvedAtEnd:   req.GetRecoverAtEnd(),
+		AlarmLevels:     req.GetAlarmLevels(),
+		AlarmStatuses:   types.SliceTo(req.GetAlarmStatuses(), func(item api.AlertStatus) vobj.AlertStatus { return vobj.AlertStatus(item) }),
+		Keyword:         req.GetKeyword(),
+	}
+	list, err := s.alarmBiz.ListRealTimeAlarms(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.ListAlarmReply{
+		List: types.SliceTo(list, func(item *bizmodel.RealtimeAlarm) *adminapi.RealtimeAlarmItem {
+			return build.NewBuilder().WithContext(ctx).WithRealTimeAlarm(item).ToAPI()
+		}),
+		Pagination: build.NewPageBuilder(params.Pagination).ToAPI(),
+	}, nil
 }

--- a/cmd/server/palace/internal/service/realtime/alarm.go
+++ b/cmd/server/palace/internal/service/realtime/alarm.go
@@ -3,14 +3,14 @@ package realtime
 import (
 	"context"
 
-	pb "github.com/aide-family/moon/api/admin/realtime"
+	realtimeapi "github.com/aide-family/moon/api/admin/realtime"
 	"github.com/aide-family/moon/cmd/server/palace/internal/biz"
 	"github.com/aide-family/moon/cmd/server/palace/internal/service/build"
 )
 
 // AlarmService 实时告警数据服务
 type AlarmService struct {
-	pb.UnimplementedAlarmServer
+	realtimeapi.UnimplementedAlarmServer
 
 	alarmBiz *biz.AlarmBiz
 }
@@ -23,13 +23,13 @@ func NewAlarmService(alarmBiz *biz.AlarmBiz) *AlarmService {
 }
 
 // GetAlarm 获取实时告警数据
-func (s *AlarmService) GetAlarm(ctx context.Context, req *pb.GetAlarmRequest) (*pb.GetAlarmReply, error) {
+func (s *AlarmService) GetAlarm(ctx context.Context, req *realtimeapi.GetAlarmRequest) (*realtimeapi.GetAlarmReply, error) {
 	params := build.NewBuilder().RealTimeAlarmModule().WithAPIGetAlarmRequest(req).ToBo()
 	realtimeAlarmDetail, err := s.alarmBiz.GetRealTimeAlarm(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return &pb.GetAlarmReply{
+	return &realtimeapi.GetAlarmReply{
 		Detail: build.NewBuilder().WithContext(ctx).RealTimeAlarmModule().
 			WithDoRealtimeAlarm(realtimeAlarmDetail).
 			ToAPI(),
@@ -37,13 +37,13 @@ func (s *AlarmService) GetAlarm(ctx context.Context, req *pb.GetAlarmRequest) (*
 }
 
 // ListAlarm 获取实时告警数据列表
-func (s *AlarmService) ListAlarm(ctx context.Context, req *pb.ListAlarmRequest) (*pb.ListAlarmReply, error) {
+func (s *AlarmService) ListAlarm(ctx context.Context, req *realtimeapi.ListAlarmRequest) (*realtimeapi.ListAlarmReply, error) {
 	params := build.NewBuilder().RealTimeAlarmModule().WithAPIListAlarmRequest(req).ToBo()
 	list, err := s.alarmBiz.ListRealTimeAlarms(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return &pb.ListAlarmReply{
+	return &realtimeapi.ListAlarmReply{
 		List: build.NewBuilder().WithContext(ctx).
 			RealTimeAlarmModule().
 			WithDostRealtimeAlarm(list).

--- a/cmd/server/palace/internal/service/realtime/dashboard.go
+++ b/cmd/server/palace/internal/service/realtime/dashboard.go
@@ -24,7 +24,7 @@ func NewDashboardService(dashboardBiz *biz.DashboardBiz) *DashboardService {
 
 // CreateDashboard 创建监控大盘
 func (s *DashboardService) CreateDashboard(ctx context.Context, req *pb.CreateDashboardRequest) (*pb.CreateDashboardReply, error) {
-	params := build.NewBuilder().WithContext(ctx).DashboardModule().WithAddDashboardParams(req).ToBo()
+	params := build.NewBuilder().WithContext(ctx).DashboardModule().WithAPIAddDashboardParams(req).ToBo()
 	if err := s.dashboardBiz.CreateDashboard(ctx, params); err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (s *DashboardService) UpdateDashboard(ctx context.Context, req *pb.UpdateDa
 	params := build.NewBuilder().
 		WithContext(ctx).
 		DashboardModule().
-		WithUpdateDashboardParams(req).
+		WithAPIUpdateDashboardParams(req).
 		ToBo()
 	if err := s.dashboardBiz.UpdateDashboard(ctx, params); err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (s *DashboardService) DeleteDashboard(ctx context.Context, req *pb.DeleteDa
 	params := build.NewBuilder().
 		WithContext(ctx).
 		DashboardModule().
-		WithDeleteDashboardParams(req).
+		WithAPIDeleteDashboardParams(req).
 		ToBo()
 	if err := s.dashboardBiz.DeleteDashboard(ctx, params); err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s *DashboardService) ListDashboard(ctx context.Context, req *pb.ListDashbo
 	params := build.NewBuilder().
 		WithContext(ctx).
 		DashboardModule().
-		WithQueryDashboardListParams(req).
+		WithAPIQueryDashboardListParams(req).
 		ToBo()
 	list, err := s.dashboardBiz.ListDashboard(ctx, params)
 	if err != nil {
@@ -100,7 +100,7 @@ func (s *DashboardService) ListDashboardSelect(ctx context.Context, req *pb.List
 	params := build.NewBuilder().
 		WithContext(ctx).
 		DashboardModule().
-		WithQueryDashboardSelectParams(req).
+		WithAPIQueryDashboardSelectParams(req).
 		ToBo()
 	list, err := s.dashboardBiz.ListDashboard(ctx, params)
 	if err != nil {

--- a/cmd/server/palace/internal/service/realtime/dashboard.go
+++ b/cmd/server/palace/internal/service/realtime/dashboard.go
@@ -3,14 +3,14 @@ package realtime
 import (
 	"context"
 
-	pb "github.com/aide-family/moon/api/admin/realtime"
+	realtimeapi "github.com/aide-family/moon/api/admin/realtime"
 	"github.com/aide-family/moon/cmd/server/palace/internal/biz"
 	"github.com/aide-family/moon/cmd/server/palace/internal/service/build"
 )
 
 // DashboardService 监控大盘服务
 type DashboardService struct {
-	pb.UnimplementedDashboardServer
+	realtimeapi.UnimplementedDashboardServer
 
 	dashboardBiz *biz.DashboardBiz
 }
@@ -23,16 +23,16 @@ func NewDashboardService(dashboardBiz *biz.DashboardBiz) *DashboardService {
 }
 
 // CreateDashboard 创建监控大盘
-func (s *DashboardService) CreateDashboard(ctx context.Context, req *pb.CreateDashboardRequest) (*pb.CreateDashboardReply, error) {
+func (s *DashboardService) CreateDashboard(ctx context.Context, req *realtimeapi.CreateDashboardRequest) (*realtimeapi.CreateDashboardReply, error) {
 	params := build.NewBuilder().WithContext(ctx).DashboardModule().WithAPIAddDashboardParams(req).ToBo()
 	if err := s.dashboardBiz.CreateDashboard(ctx, params); err != nil {
 		return nil, err
 	}
-	return &pb.CreateDashboardReply{}, nil
+	return &realtimeapi.CreateDashboardReply{}, nil
 }
 
 // UpdateDashboard 更新监控大盘
-func (s *DashboardService) UpdateDashboard(ctx context.Context, req *pb.UpdateDashboardRequest) (*pb.UpdateDashboardReply, error) {
+func (s *DashboardService) UpdateDashboard(ctx context.Context, req *realtimeapi.UpdateDashboardRequest) (*realtimeapi.UpdateDashboardReply, error) {
 	params := build.NewBuilder().
 		WithContext(ctx).
 		DashboardModule().
@@ -41,11 +41,11 @@ func (s *DashboardService) UpdateDashboard(ctx context.Context, req *pb.UpdateDa
 	if err := s.dashboardBiz.UpdateDashboard(ctx, params); err != nil {
 		return nil, err
 	}
-	return &pb.UpdateDashboardReply{}, nil
+	return &realtimeapi.UpdateDashboardReply{}, nil
 }
 
 // DeleteDashboard 删除监控大盘
-func (s *DashboardService) DeleteDashboard(ctx context.Context, req *pb.DeleteDashboardRequest) (*pb.DeleteDashboardReply, error) {
+func (s *DashboardService) DeleteDashboard(ctx context.Context, req *realtimeapi.DeleteDashboardRequest) (*realtimeapi.DeleteDashboardReply, error) {
 	params := build.NewBuilder().
 		WithContext(ctx).
 		DashboardModule().
@@ -54,12 +54,12 @@ func (s *DashboardService) DeleteDashboard(ctx context.Context, req *pb.DeleteDa
 	if err := s.dashboardBiz.DeleteDashboard(ctx, params); err != nil {
 		return nil, err
 	}
-	return &pb.DeleteDashboardReply{}, nil
+	return &realtimeapi.DeleteDashboardReply{}, nil
 }
 
 // GetDashboard 获取监控大盘
-func (s *DashboardService) GetDashboard(ctx context.Context, req *pb.GetDashboardRequest) (*pb.GetDashboardReply, error) {
-	detail, err := s.dashboardBiz.GetDashboard(ctx, req.Id)
+func (s *DashboardService) GetDashboard(ctx context.Context, req *realtimeapi.GetDashboardRequest) (*realtimeapi.GetDashboardReply, error) {
+	detail, err := s.dashboardBiz.GetDashboard(ctx, req.GetId())
 	if err != nil {
 		return nil, err
 	}
@@ -68,13 +68,13 @@ func (s *DashboardService) GetDashboard(ctx context.Context, req *pb.GetDashboar
 		DashboardModule().
 		WithDoDashboard(detail).
 		ToAPI()
-	return &pb.GetDashboardReply{
+	return &realtimeapi.GetDashboardReply{
 		Detail: apiDetail,
 	}, nil
 }
 
 // ListDashboard 获取监控大盘列表
-func (s *DashboardService) ListDashboard(ctx context.Context, req *pb.ListDashboardRequest) (*pb.ListDashboardReply, error) {
+func (s *DashboardService) ListDashboard(ctx context.Context, req *realtimeapi.ListDashboardRequest) (*realtimeapi.ListDashboardReply, error) {
 	params := build.NewBuilder().
 		WithContext(ctx).
 		DashboardModule().
@@ -89,14 +89,14 @@ func (s *DashboardService) ListDashboard(ctx context.Context, req *pb.ListDashbo
 		DashboardModule().
 		WithDoDashboardList(list).
 		ToAPIs()
-	return &pb.ListDashboardReply{
+	return &realtimeapi.ListDashboardReply{
 		List:       apiList,
 		Pagination: build.NewPageBuilder(params.Page).ToAPI(),
 	}, nil
 }
 
 // ListDashboardSelect 获取监控大盘下拉列表
-func (s *DashboardService) ListDashboardSelect(ctx context.Context, req *pb.ListDashboardSelectRequest) (*pb.ListDashboardSelectReply, error) {
+func (s *DashboardService) ListDashboardSelect(ctx context.Context, req *realtimeapi.ListDashboardSelectRequest) (*realtimeapi.ListDashboardSelectReply, error) {
 	params := build.NewBuilder().
 		WithContext(ctx).
 		DashboardModule().
@@ -111,7 +111,7 @@ func (s *DashboardService) ListDashboardSelect(ctx context.Context, req *pb.List
 		DashboardModule().
 		WithDoDashboardList(list).
 		ToSelects()
-	return &pb.ListDashboardSelectReply{
+	return &realtimeapi.ListDashboardSelectReply{
 		List:       apiList,
 		Pagination: build.NewPageBuilder(params.Page).ToAPI(),
 	}, nil

--- a/cmd/server/palace/internal/service/realtime/dashboard.go
+++ b/cmd/server/palace/internal/service/realtime/dashboard.go
@@ -4,44 +4,115 @@ import (
 	"context"
 
 	pb "github.com/aide-family/moon/api/admin/realtime"
+	"github.com/aide-family/moon/cmd/server/palace/internal/biz"
+	"github.com/aide-family/moon/cmd/server/palace/internal/service/build"
 )
 
 // DashboardService 监控大盘服务
 type DashboardService struct {
 	pb.UnimplementedDashboardServer
+
+	dashboardBiz *biz.DashboardBiz
 }
 
 // NewDashboardService 创建监控大盘服务
-func NewDashboardService() *DashboardService {
-	return &DashboardService{}
+func NewDashboardService(dashboardBiz *biz.DashboardBiz) *DashboardService {
+	return &DashboardService{
+		dashboardBiz: dashboardBiz,
+	}
 }
 
 // CreateDashboard 创建监控大盘
 func (s *DashboardService) CreateDashboard(ctx context.Context, req *pb.CreateDashboardRequest) (*pb.CreateDashboardReply, error) {
+	params := build.NewBuilder().WithContext(ctx).DashboardModule().WithAddDashboardParams(req).ToBo()
+	if err := s.dashboardBiz.CreateDashboard(ctx, params); err != nil {
+		return nil, err
+	}
 	return &pb.CreateDashboardReply{}, nil
 }
 
 // UpdateDashboard 更新监控大盘
 func (s *DashboardService) UpdateDashboard(ctx context.Context, req *pb.UpdateDashboardRequest) (*pb.UpdateDashboardReply, error) {
+	params := build.NewBuilder().
+		WithContext(ctx).
+		DashboardModule().
+		WithUpdateDashboardParams(req).
+		ToBo()
+	if err := s.dashboardBiz.UpdateDashboard(ctx, params); err != nil {
+		return nil, err
+	}
 	return &pb.UpdateDashboardReply{}, nil
 }
 
 // DeleteDashboard 删除监控大盘
 func (s *DashboardService) DeleteDashboard(ctx context.Context, req *pb.DeleteDashboardRequest) (*pb.DeleteDashboardReply, error) {
+	params := build.NewBuilder().
+		WithContext(ctx).
+		DashboardModule().
+		WithDeleteDashboardParams(req).
+		ToBo()
+	if err := s.dashboardBiz.DeleteDashboard(ctx, params); err != nil {
+		return nil, err
+	}
 	return &pb.DeleteDashboardReply{}, nil
 }
 
 // GetDashboard 获取监控大盘
 func (s *DashboardService) GetDashboard(ctx context.Context, req *pb.GetDashboardRequest) (*pb.GetDashboardReply, error) {
-	return &pb.GetDashboardReply{}, nil
+	detail, err := s.dashboardBiz.GetDashboard(ctx, req.Id)
+	if err != nil {
+		return nil, err
+	}
+	apiDetail := build.NewBuilder().
+		WithContext(ctx).
+		DashboardModule().
+		WithDoDashboard(detail).
+		ToAPI()
+	return &pb.GetDashboardReply{
+		Detail: apiDetail,
+	}, nil
 }
 
 // ListDashboard 获取监控大盘列表
 func (s *DashboardService) ListDashboard(ctx context.Context, req *pb.ListDashboardRequest) (*pb.ListDashboardReply, error) {
-	return &pb.ListDashboardReply{}, nil
+	params := build.NewBuilder().
+		WithContext(ctx).
+		DashboardModule().
+		WithQueryDashboardListParams(req).
+		ToBo()
+	list, err := s.dashboardBiz.ListDashboard(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	apiList := build.NewBuilder().
+		WithContext(ctx).
+		DashboardModule().
+		WithDoDashboardList(list).
+		ToAPIs()
+	return &pb.ListDashboardReply{
+		List:       apiList,
+		Pagination: build.NewPageBuilder(params.Page).ToAPI(),
+	}, nil
 }
 
 // ListDashboardSelect 获取监控大盘下拉列表
 func (s *DashboardService) ListDashboardSelect(ctx context.Context, req *pb.ListDashboardSelectRequest) (*pb.ListDashboardSelectReply, error) {
-	return &pb.ListDashboardSelectReply{}, nil
+	params := build.NewBuilder().
+		WithContext(ctx).
+		DashboardModule().
+		WithQueryDashboardSelectParams(req).
+		ToBo()
+	list, err := s.dashboardBiz.ListDashboard(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	apiList := build.NewBuilder().
+		WithContext(ctx).
+		DashboardModule().
+		WithDoDashboardList(list).
+		ToSelects()
+	return &pb.ListDashboardSelectReply{
+		List:       apiList,
+		Pagination: build.NewPageBuilder(params.Page).ToAPI(),
+	}, nil
 }

--- a/cmd/server/palace/internal/service/strategy/strategy.go
+++ b/cmd/server/palace/internal/service/strategy/strategy.go
@@ -209,7 +209,7 @@ func (s *Service) GetStrategy(ctx context.Context, req *strategyapi.GetStrategyR
 		return nil, err
 	}
 	return &strategyapi.GetStrategyReply{
-		Detail: build.NewBuilder().WithAPIStrategy(strategy).ToAPI(ctx),
+		Detail: build.NewBuilder().WithContext(ctx).WithAPIStrategy(strategy).ToAPI(),
 	}, nil
 }
 
@@ -233,7 +233,7 @@ func (s *Service) ListStrategy(ctx context.Context, req *strategyapi.ListStrateg
 	return &strategyapi.ListStrategyReply{
 		Pagination: build.NewPageBuilder(params.Page).ToAPI(),
 		List: types.SliceTo(strategies, func(strategy *bizmodel.Strategy) *admin.StrategyItem {
-			return build.NewBuilder().WithAPIStrategy(strategy).ToAPI(ctx)
+			return build.NewBuilder().WithContext(ctx).WithAPIStrategy(strategy).ToAPI()
 		}),
 	}, nil
 }

--- a/docs/i18n/zh-CN/dev.md
+++ b/docs/i18n/zh-CN/dev.md
@@ -5,6 +5,11 @@
 在开发前， 请确保你已经安装了go环境，以及protobuf、kratos框架相关依赖
 如果没有， 请参考：[kratos项目初始化依赖安装](https://go-kratos.dev/docs/getting-started/start)
 
+mac安装protoc插件
+```bash
+brew install protobuf
+```
+
 安装自定义errors生成插件, 此插件支持i18n
 
 ```bash

--- a/pkg/palace/model/bizmodel/dashboard.go
+++ b/pkg/palace/model/bizmodel/dashboard.go
@@ -1,0 +1,44 @@
+package bizmodel
+
+import (
+	"encoding/json"
+
+	"github.com/aide-family/moon/pkg/palace/model"
+	"github.com/aide-family/moon/pkg/vobj"
+)
+
+const tableNameDashboard = "dashboard"
+
+// Dashboard mapped from table <dashboard>
+type Dashboard struct {
+	model.AllFieldModel
+	Name   string      `gorm:"column:name;type:varchar(64);not null;comment:仪表盘名称" json:"name"`     // 仪表盘名称
+	Status vobj.Status `gorm:"column:status;type:int;not null;comment:仪表盘状态" json:"status"`         // 仪表盘状态
+	Remark string      `gorm:"column:remark;type:varchar(255);not null;comment:描述信息" json:"remark"` // 描述信息
+	Color  string      `gorm:"column:color;type:varchar(64);not null;comment:颜色" json:"color"`
+	// 仪表盘图表
+	Charts []*DashboardChart `gorm:"foreignKey:DashboardID" json:"charts"`
+	// 仪表盘策略组
+	StrategyGroups []*StrategyGroup `gorm:"many2many:dashboard_strategy_groups" json:"strategy_groups"`
+}
+
+// String json string
+func (c *Dashboard) String() string {
+	bs, _ := json.Marshal(c)
+	return string(bs)
+}
+
+// UnmarshalBinary redis存储实现
+func (c *Dashboard) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, c)
+}
+
+// MarshalBinary redis存储实现
+func (c *Dashboard) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(c)
+}
+
+// TableName Dashboard's table name
+func (*Dashboard) TableName() string {
+	return tableNameDashboard
+}

--- a/pkg/palace/model/bizmodel/dashboard_chart.go
+++ b/pkg/palace/model/bizmodel/dashboard_chart.go
@@ -1,0 +1,44 @@
+package bizmodel
+
+import (
+	"encoding/json"
+
+	"github.com/aide-family/moon/pkg/palace/model"
+	"github.com/aide-family/moon/pkg/vobj"
+)
+
+const tableNameDashboardChart = "dashboard_charts"
+
+// DashboardChart mapped from table <dashboard_charts>
+type DashboardChart struct {
+	model.AllFieldModel
+	Name        string                  `gorm:"column:name;type:varchar(64);not null;comment:仪表盘名称" json:"name"`     // 仪表盘名称
+	Status      vobj.Status             `gorm:"column:status;type:int;not null;comment:仪表盘状态" json:"status"`         // 仪表盘状态
+	Remark      string                  `gorm:"column:remark;type:varchar(255);not null;comment:描述信息" json:"remark"` // 描述信息
+	URL         string                  `gorm:"column:url;type:text;not null;comment:图表地址" json:"url"`
+	DashboardID uint32                  `gorm:"column:dashboard_id;type:int unsigned;not null;comment:仪表盘ID" json:"dashboard_id"`
+	ChartType   vobj.DashboardChartType `gorm:"column:chart_type;type:int;not null;comment:图表类型" json:"chart_type"`
+	Width       string                  `gorm:"column:width;type:varchar(64);not null;comment:图表宽度" json:"width"`
+	Height      string                  `gorm:"column:height;type:varchar(64);not null;comment:图表高度" json:"height"`
+}
+
+// String json string
+func (c *DashboardChart) String() string {
+	bs, _ := json.Marshal(c)
+	return string(bs)
+}
+
+// UnmarshalBinary redis存储实现
+func (c *DashboardChart) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, c)
+}
+
+// MarshalBinary redis存储实现
+func (c *DashboardChart) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(c)
+}
+
+// TableName DashboardChart's table name
+func (*DashboardChart) TableName() string {
+	return tableNameDashboardChart
+}

--- a/pkg/palace/model/bizmodel/init.go
+++ b/pkg/palace/model/bizmodel/init.go
@@ -21,6 +21,8 @@ func Models() []any {
 		&StrategyLevelTemplate{},
 		&SendStrategy{},
 		&StrategyGroup{},
+		&Dashboard{},
+		&DashboardChart{},
 	}
 }
 

--- a/pkg/palace/model/bizmodel/realtime_alarm.go
+++ b/pkg/palace/model/bizmodel/realtime_alarm.go
@@ -13,10 +13,8 @@ const tableNameRealtimeAlarm = "realtime_alarm"
 type RealtimeAlarm struct {
 	model.EasyModel
 	// 发生这条告警的具体策略信息
-	StrategyID uint32    `gorm:"column:strategy_id;type:int unsigned;not null;uniqueIndex:idx__ar__strategy_id,priority:1;comment:策略ID"`
-	Strategy   *Strategy `gorm:"foreignKey:StrategyID"`
-	LevelID    uint32    `gorm:"column:level_id;type:int unsigned;not null;uniqueIndex:idx__ar__level_id,priority:1;comment:告警等级ID"`
-	Level      *SysDict  `gorm:"foreignKey:LevelID"`
+	StrategyID uint32 `gorm:"column:strategy_id;type:int unsigned;not null;uniqueIndex:idx__ar__strategy_id,priority:1;comment:策略ID"`
+	LevelID    uint32 `gorm:"column:level_id;type:int unsigned;not null;uniqueIndex:idx__ar__level_id,priority:1;comment:告警等级ID"`
 	// 告警状态: 1告警;2恢复
 	Status vobj.AlertStatus `gorm:"column:status;type:tinyint;not null;default:1;comment:告警状态: 1告警;2恢复"`
 	// 告警时间
@@ -32,8 +30,7 @@ type RealtimeAlarm struct {
 	// 触发告警表达式
 	Expr string `gorm:"column:expr;type:text;not null;comment:告警表达式"`
 	// 数据源
-	DatasourceID uint32      `gorm:"column:datasource_id;type:int unsigned;not null;comment:数据源ID"`
-	Datasource   *Datasource `gorm:"foreignKey:DatasourceID"`
+	DatasourceID uint32 `gorm:"column:datasource_id;type:int unsigned;not null;comment:数据源ID"`
 	// 指纹
 	Fingerprint string `gorm:"column:fingerprint;type:varchar(255);not null;comment:fingerprint;uniqueIndex"`
 }

--- a/pkg/util/types/page.go
+++ b/pkg/util/types/page.go
@@ -59,6 +59,9 @@ func NewPage(pageNum, pageSize int) Pagination {
 
 // NewPagination 获取分页器
 func NewPagination(page *api.PaginationReq) Pagination {
+	if IsNil(page) {
+		return nil
+	}
 	return NewPage(int(page.GetPageNum()), int(page.GetPageSize()))
 }
 

--- a/pkg/vobj/dashboardcharttype.go
+++ b/pkg/vobj/dashboardcharttype.go
@@ -1,0 +1,20 @@
+package vobj
+
+// DashboardChartType 仪表盘图表类型
+//
+//go:generate go run ../../cmd/server/stringer/cmd.go -type=DashboardChartType -linecomment
+type DashboardChartType int
+
+const (
+	// DashboardChartTypeUnknown 未知
+	DashboardChartTypeUnknown DashboardChartType = iota // 未知
+
+	// DashboardChartTypeFullScreen 全屏
+	DashboardChartTypeFullScreen // 全屏
+
+	// DashboardChartTypeRow 行
+	DashboardChartTypeRow // 行
+
+	// DashboardChartTypeCol 列
+	DashboardChartTypeCol // 列
+)


### PR DESCRIPTION
在用户列表的GetUserSelectListRequest消息中，去掉了pagination字段的必填约束，使得请求不再强制需要分页参数。此外，对page.go中的NewPagination函数进行了修改，增加了对分页器参数的空检查，以避免潜在的空指针异常。

BREAKING CHANGE: GetUserSelectListRequest的pagination字段不再强制要求。调用方可以省略该字段，此时将不会进行分页处理。请确保更新所有相关客户端代码以适应这一变化。